### PR TITLE
Delete data form dead pawns

### DIFF
--- a/source/PromptStorageComponent.cs
+++ b/source/PromptStorageComponent.cs
@@ -1,5 +1,7 @@
-using Verse;
+using RimWorld;
 using System.Collections.Generic;
+using System.Linq;
+using Verse;
 
 namespace EchoColony
 {
@@ -40,16 +42,43 @@ namespace EchoColony
                 voicesByColonist = new Dictionary<string, string>();
         }
 
-        public override void FinalizeInit()
-{
-    base.FinalizeInit();
+        public void CleanupOrphanedPrompts()
+        {
+            // Verificamos que los diccionarios no sean nulos antes de empezar
+            if (promptsByColonist == null) return;
 
-    // 🔁 Agregar TTSVoiceLoaderComponent si no está
-    if (Current.Game.GetComponent<TTSVoiceLoaderComponent>() == null)
-    {
-        Current.Game.components.Add(new TTSVoiceLoaderComponent(Current.Game));
-        Log.Message("[EchoColony] 🔁 TTSVoiceLoaderComponent agregado desde PromptStorageComponent");
-    }
-}
+            // PawnsFinder requiere System.Linq para el .Select y .Where
+            var validPawnIDs = new HashSet<string>(
+                PawnsFinder.AllMapsWorldAndTemporary_AliveOrDead
+                    .Where(p => p != null)
+                    .Select(p => p.ThingID)
+            );
+
+            List<string> keysToRemove = promptsByColonist.Keys
+                .Where(key => !validPawnIDs.Contains(key))
+                .ToList();
+
+            foreach (var key in keysToRemove)
+            {
+                promptsByColonist.Remove(key);
+                voicesByColonist?.Remove(key);
+                ignoreAgeByColonist?.Remove(key);
+                Log.Message($"[EchoColony] Cleaned up data for obsolete Pawn ID: {key}");
+            }
+        }
+
+        public override void FinalizeInit()
+        {
+            base.FinalizeInit();
+
+            CleanupOrphanedPrompts();
+
+            // 🔁 Agregar TTSVoiceLoaderComponent si no está
+            if (Current.Game.GetComponent<TTSVoiceLoaderComponent>() == null)
+            {
+                Current.Game.components.Add(new TTSVoiceLoaderComponent(Current.Game));
+                Log.Message("[EchoColony] 🔁 TTSVoiceLoaderComponent agregado desde PromptStorageComponent");
+            }
+        }
     }
 }

--- a/source/group/GroupChatGameComponent.cs
+++ b/source/group/GroupChatGameComponent.cs
@@ -1,6 +1,7 @@
-using Verse;
+using RimWorld;
 using System.Collections.Generic;
 using System.Linq;
+using Verse;
 
 namespace EchoColony
 {
@@ -62,8 +63,52 @@ namespace EchoColony
             session.History.Clear();
         }
 
+        //public void CleanupOrphanedGroupChats()
+        //{
+        //    if (groupChats == null) return;
+
+        //    // 1. Obtener todos los IDs de peones que el juego aún reconoce como existentes
+        //    var validPawnIDs = new HashSet<string>(
+        //        PawnsFinder.AllMapsWorldAndTemporary_AliveOrDead
+        //            .Where(p => p != null)
+        //            .Select(p => p.ThingID)
+        //    );
+
+        //    // 2. Identificar sesiones a eliminar
+        //    List<string> sessionsToRemove = new List<string>();
+
+        //    foreach (var kvp in groupChats)
+        //    {
+        //        GroupChatSession session = kvp.Value;
+
+        //        // Criterios de eliminación:
+        //        // - La sesión es nula
+        //        // - No tiene participantes
+        //        // - Al menos UNO de los participantes ya no existe en el mundo
+        //        if (session == null ||
+        //            session.ParticipantIds == null ||
+        //            session.ParticipantIds.Count == 0 ||
+        //            session.ParticipantIds.Any(id => !validPawnIDs.Contains(id)))
+        //        {
+        //            sessionsToRemove.Add(kvp.Key);
+        //        }
+        //    }
+
+        //    // 3. Ejecutar la limpieza
+        //    foreach (var sessionId in sessionsToRemove)
+        //    {
+        //        groupChats.Remove(sessionId);
+        //    }
+
+        //    if (sessionsToRemove.Count > 0)
+        //    {
+        //        Log.Message($"[EchoColony] Se eliminaron {sessionsToRemove.Count} sesiones de chat grupal (participantes inexistentes o datos corruptos).");
+        //    }
+        //}
+
         public override void ExposeData()
         {
+            base.ExposeData();
             Scribe_Collections.Look(ref groupChats, "groupChats", LookMode.Value, LookMode.Deep);
 
             if (Scribe.mode == LoadSaveMode.PostLoadInit)
@@ -71,17 +116,66 @@ namespace EchoColony
                 if (groupChats == null)
                     groupChats = new Dictionary<string, GroupChatSession>();
 
-                // Filtrar sesiones corruptas que no tienen participantes
-                var invalidSessions = groupChats
-                    .Where(kv => kv.Value == null || kv.Value.ParticipantIds == null || kv.Value.ParticipantIds.Count == 0)
-                    .Select(kv => kv.Key)
-                    .ToList();
+            }
+        }
+        public override void LoadedGame()
+        {
+            base.LoadedGame();
+            CleanupOrphanedGroupChats();
+        }
 
-                foreach (var id in invalidSessions)
+        public void CleanupOrphanedGroupChats()
+        {
+            if (groupChats == null || groupChats.Count == 0) return;
+
+            // 1. Crear un set de todos los IDs de peones que existen actualmente en el juego
+            // Incluye colonos, prisioneros, enemigos muertos, peones en caravanas, etc.
+            HashSet<string> allValidIds = new HashSet<string>();
+
+            foreach (Pawn p in Find.WorldPawns.AllPawnsAliveOrDead)
+            {
+                if (p != null) allValidIds.Add(p.ThingID);
+            }
+
+            foreach (Map map in Find.Maps)
+            {
+                foreach (Pawn p in map.mapPawns.AllPawns)
                 {
-                    Log.Warning($"[EchoColony] Sesión inválida eliminada al cargar: {id}");
-                    groupChats.Remove(id);
+                    if (p != null) allValidIds.Add(p.ThingID);
                 }
+            }
+
+            // 2. Identificar sesiones donde FALTE algún participante
+            List<string> sessionsToRemove = new List<string>();
+
+            foreach (var kvp in groupChats)
+            {
+                GroupChatSession session = kvp.Value;
+
+                if (session == null || session.ParticipantIds == null || session.ParticipantIds.Count == 0)
+                {
+                    sessionsToRemove.Add(kvp.Key);
+                    continue;
+                }
+
+                // Si uno solo de los participantes ya no está en el set global, marcamos para borrar
+                bool anyParticipantMissing = session.ParticipantIds.Any(id => !allValidIds.Contains(id));
+
+                if (anyParticipantMissing)
+                {
+                    sessionsToRemove.Add(kvp.Key);
+                }
+            }
+
+            // 3. Ejecutar la eliminación
+            foreach (string sessionId in sessionsToRemove)
+            {
+                groupChats.Remove(sessionId);
+            }
+
+            if (sessionsToRemove.Count > 0)
+            {
+                Log.Message($"[EchoColony] Limpieza de Grupos: Se eliminaron {sessionsToRemove.Count} sesiones porque uno o más miembros ya no existen.");
             }
         }
     }


### PR DESCRIPTION
I added code to delete conversations, individual pawn prompts, memories, and group chats for dead or missing pawns.
Check it out. I tested it, and it seems to work.