### PR TITLE
Implement group prompt system with manager window

### DIFF
--- a/source/ColonistPromptContextBuilder.cs
+++ b/source/ColonistPromptContextBuilder.cs
@@ -30,7 +30,14 @@ namespace EchoColony
             sb.AppendLine(systemPrompt);
             if (!string.IsNullOrWhiteSpace(globalPrompt))
                 sb.AppendLine(globalPrompt.Trim());
-
+            
+             string groupPrompt = ColonistGroupManager.GetGroupPrompt(pawn);
+            if (!string.IsNullOrWhiteSpace(groupPrompt))
+            {
+                sb.AppendLine("# Additional Instructions:");
+                sb.AppendLine(groupPrompt.Trim());
+            }  
+            
             if (!string.IsNullOrWhiteSpace(customPrompt))
             {
                 sb.AppendLine($"# Custom Instructions for {pawn.LabelShort}:");
@@ -1059,6 +1066,13 @@ namespace EchoColony
 
             if (!string.IsNullOrWhiteSpace(globalPrompt))
                 sb.AppendLine(globalPrompt.Trim());
+
+            string groupPrompt = ColonistGroupManager.GetGroupPrompt(pawn);
+            if (!string.IsNullOrWhiteSpace(groupPrompt))
+            {
+                sb.AppendLine("# Additional Instructions:");
+                sb.AppendLine(groupPrompt.Trim());
+            }    
 
             if (!string.IsNullOrWhiteSpace(customPrompt))
             {

--- a/source/ColonistPromptEditor.cs
+++ b/source/ColonistPromptEditor.cs
@@ -16,15 +16,14 @@ namespace EchoColony
 
         public ColonistPromptEditor(Pawn pawn)
         {
-            this.pawn = pawn;
+            this.pawn       = pawn;
             this.tempPrompt = ColonistPromptManager.GetPrompt(pawn);
-            this.closeOnClickedOutside = true;
-            this.doCloseX = true;
+            this.closeOnClickedOutside  = true;
+            this.doCloseX               = true;
             this.absorbInputAroundWindow = true;
-            this.forcePause = true;
-            this.draggable = true;
+            this.forcePause             = true;
+            this.draggable              = true;
 
-            // 🧠 Restaurar voz guardada solo si Player2 está activo y TTS habilitado
             if (MyMod.Settings.modelSource == ModelSource.Player2 && MyMod.Settings.enableTTS)
             {
                 string savedVoice = ColonistVoiceManager.GetVoice(pawn);
@@ -35,94 +34,71 @@ namespace EchoColony
                     Log.Message($"[EchoColony] Loaded stored voice '{savedVoice}' for {pawn.LabelShort} into memory.");
                 }
             }
-    
-            // Solo cargar caracteres de Player2 si está activo
+
             if (MyMod.Settings.modelSource == ModelSource.Player2 && Player2CharacterCache.Characters.Count == 0)
             {
                 MyStoryModComponent.Instance.StartCoroutine(Player2Importer.LoadCharacters());
             }
         }
 
-        public override Vector2 InitialSize => new Vector2(500f, 500f);
+        // Slightly taller to accommodate the group section
+        public override Vector2 InitialSize => new Vector2(500f, 545f);
 
         public override void DoWindowContents(Rect inRect)
         {
             float currentY = 0f;
 
-            // ✅ HEADER CON TÍTULO Y BOTÓN DE MEMORIAS (SIN CHECKBOX)
             DrawHeader(inRect, ref currentY);
 
-            // Selector de voz (solo si Player2 está activo Y TTS está habilitado)
             if (MyMod.Settings.modelSource == ModelSource.Player2 && MyMod.Settings.enableTTS)
-            {
                 DrawVoiceSection(inRect, ref currentY);
-            }
 
-            // Sección de prompt personalizado (CON CHECKBOX)
+            DrawGroupSection(inRect, ref currentY);
+
             DrawPromptSection(inRect, ref currentY);
 
-            // Botón de guardar
             DrawSaveButton(inRect);
         }
 
         private void DrawHeader(Rect inRect, ref float currentY)
         {
-            // ✅ ÁREA DEL HEADER LIMPIA
-            Rect headerRect = new Rect(0, currentY, inRect.width, 35f);
-
-            // Título principal
             Text.Font = GameFont.Medium;
-            string title = "EchoColony.PersonalizingTitle".Translate(pawn.LabelCap);
-            Widgets.Label(new Rect(0, currentY, inRect.width - 100f, 30f), title);
+            Widgets.Label(new Rect(0, currentY, inRect.width - 100f, 30f),
+                "EchoColony.PersonalizingTitle".Translate(pawn.LabelCap));
             Text.Font = GameFont.Small;
 
-            // ✅ BOTÓN DE MEMORIAS MEJORADO (esquina superior derecha)
             Rect memoryButtonRect = new Rect(inRect.width - 90f, currentY, 85f, 30f);
-
-            // Fondo sutil para el botón
             Color originalColor = GUI.color;
-            GUI.color = new Color(0.8f, 0.9f, 1f, 0.8f); // Azul claro sutil
-
+            GUI.color = new Color(0.8f, 0.9f, 1f, 0.8f);
             if (Widgets.ButtonText(memoryButtonRect, "EchoColony.MemoriesButton".Translate()))
-            {
                 Find.WindowStack.Add(new ColonistMemoryViewer(pawn));
-            }
-
             GUI.color = originalColor;
 
-            // Tooltip informativo
             TooltipHandler.TipRegion(memoryButtonRect,
                 "EchoColony.MemoriesTooltip".Translate(pawn.LabelShort));
 
-            currentY += 40f; // Espacio después del header
+            currentY += 40f;
         }
 
         private void DrawVoiceSection(Rect inRect, ref float currentY)
         {
-            // ✅ SECCIÓN DE VOZ CON MEJOR ORGANIZACIÓN
-            
-            // Título de la sección con línea separadora
-            Rect voiceTitleRect = new Rect(0, currentY, inRect.width, 25f);
-            Widgets.Label(voiceTitleRect, "EchoColony.VoiceConfigurationTitle".Translate());
+            Widgets.Label(new Rect(0, currentY, inRect.width, 25f),
+                "EchoColony.VoiceConfigurationTitle".Translate());
             currentY += 30f;
 
-            // Línea separadora sutil
-            Rect separatorRect = new Rect(0, currentY - 5f, inRect.width, 1f);
-            Widgets.DrawBoxSolid(separatorRect, new Color(0.5f, 0.5f, 0.5f, 0.3f));
+            Widgets.DrawBoxSolid(new Rect(0, currentY - 5f, inRect.width, 1f),
+                new Color(0.5f, 0.5f, 0.5f, 0.3f));
 
-            // Selector de voz
-            Rect voiceLabelRect = new Rect(0f, currentY, 50f, 30f);
-            Widgets.Label(voiceLabelRect, "EchoColony.VoiceLabel".Translate());
+            Widgets.Label(new Rect(0f, currentY, 50f, 30f), "EchoColony.VoiceLabel".Translate());
 
             Rect dropdownRect = new Rect(60f, currentY, 150f, 30f);
             if (Widgets.ButtonText(dropdownRect, GetSelectedVoiceName(pawn)))
             {
-                List<FloatMenuOption> options = new List<FloatMenuOption>();
+                var options = new List<FloatMenuOption>();
                 foreach (var voice in TTSVoiceCache.Voices)
                 {
                     string voiceId = voice.id;
-                    string displayName = $"{voice.name} [{voice.language}]";
-                    options.Add(new FloatMenuOption(displayName, () =>
+                    options.Add(new FloatMenuOption($"{voice.name} [{voice.language}]", () =>
                     {
                         ChatGameComponent.Instance.SetVoiceForPawn(pawn, voiceId);
                         ColonistVoiceManager.SetVoice(pawn, voiceId);
@@ -131,121 +107,173 @@ namespace EchoColony
                 Find.WindowStack.Add(new FloatMenu(options));
             }
 
-            // Botón de importar de Player2
             Rect importBtnRect = new Rect(220f, currentY, 100f, 30f);
-            GUI.color = new Color(0.9f, 1f, 0.9f); // Verde claro
+            GUI.color = new Color(0.9f, 1f, 0.9f);
             if (Widgets.ButtonText(importBtnRect, "EchoColony.ImportButton".Translate()))
-            {
                 HandlePlayer2Import();
-            }
             GUI.color = Color.white;
 
-            // Botón de prueba de voz
             Rect testVoiceRect = new Rect(330f, currentY, 70f, 30f);
-            GUI.color = new Color(1f, 0.9f, 0.8f); // Naranja claro
+            GUI.color = new Color(1f, 0.9f, 0.8f);
             TooltipHandler.TipRegion(testVoiceRect, "EchoColony.TestVoiceTooltip".Translate());
             if (Widgets.ButtonText(testVoiceRect, "EchoColony.TestButton".Translate()))
             {
                 string voiceId = ChatGameComponent.Instance.GetVoiceForPawn(pawn);
                 if (!string.IsNullOrEmpty(voiceId) && !string.IsNullOrEmpty(testText))
-                {
                     MyStoryModComponent.Instance.StartCoroutine(
-                        TTSManager.Speak(testText, voiceId, "female", "en_US", 1f)
-                    );
-                }
+                        TTSManager.Speak(testText, voiceId, "female", "en_US", 1f));
             }
             GUI.color = Color.white;
 
             currentY += 35f;
 
-            // Campo de texto para prueba de voz
-            Rect testTextLabelRect = new Rect(0f, currentY, 120f, 20f);
-            Widgets.Label(testTextLabelRect, "EchoColony.TestTextLabel".Translate());
-
-            Rect testTextRect = new Rect(0f, currentY + 20f, inRect.width, 30f);
+            Widgets.Label(new Rect(0f, currentY, 120f, 20f), "EchoColony.TestTextLabel".Translate());
             GUI.SetNextControlName("TestTextArea");
-            testText = Widgets.TextField(testTextRect, testText);
+            testText = Widgets.TextField(new Rect(0f, currentY + 20f, inRect.width, 30f), testText);
 
-            currentY += 65f; // Espacio después de la sección de voz
+            currentY += 65f;
+        }
+
+        /// <summary>
+        /// Compact group row: shows current group tag + Change button + Manage Groups button.
+        /// </summary>
+        private void DrawGroupSection(Rect inRect, ref float currentY)
+        {
+            // Separator
+            Widgets.DrawBoxSolid(new Rect(0, currentY, inRect.width, 1f),
+                new Color(0.5f, 0.5f, 0.5f, 0.3f));
+            currentY += 6f;
+
+            // "Group:" label
+            Widgets.Label(new Rect(0f, currentY, 48f, 26f), "Group:");
+
+            // Current group tag
+            var currentGroup = ColonistGroupManager.GetGroup(pawn);
+            float tagX = 52f;
+
+            if (currentGroup != null)
+            {
+                // Colored tag background
+                float tagW = Mathf.Min(Text.CalcSize(currentGroup.name).x + 16f, 140f);
+                Rect tagBg = new Rect(tagX, currentY + 3f, tagW, 22f);
+                Widgets.DrawBoxSolid(tagBg, new Color(currentGroup.color.r, currentGroup.color.g,
+                    currentGroup.color.b, 0.35f));
+                Widgets.DrawBox(tagBg);
+
+                // Small color dot inside tag
+                Rect dot = new Rect(tagBg.x + 4f, tagBg.y + 4f, 14f, 14f);
+                Widgets.DrawBoxSolid(dot, currentGroup.color);
+
+                Text.Anchor = TextAnchor.MiddleLeft;
+                Widgets.Label(new Rect(dot.xMax + 4f, tagBg.y, tagBg.width - dot.width - 10f, tagBg.height),
+                    currentGroup.name);
+                Text.Anchor = TextAnchor.UpperLeft;
+
+                tagX += tagW + 8f;
+            }
+            else
+            {
+                GUI.color = Color.gray;
+                Text.Anchor = TextAnchor.MiddleLeft;
+                Widgets.Label(new Rect(tagX, currentY, 80f, 26f), "None");
+                Text.Anchor = TextAnchor.UpperLeft;
+                GUI.color = Color.white;
+                tagX += 88f;
+            }
+
+            // Change button — FloatMenu with all groups + None
+            Rect changeBtn = new Rect(tagX, currentY, 60f, 26f);
+            if (Widgets.ButtonText(changeBtn, "Change"))
+            {
+                var options = new List<FloatMenuOption>();
+
+                options.Add(new FloatMenuOption("None", () => ColonistGroupManager.ClearGroup(pawn)));
+
+                foreach (var group in ColonistGroupManager.GetAllGroups())
+                {
+                    string groupId   = group.id;
+                    string groupName = group.name;
+                    options.Add(new FloatMenuOption(groupName, () =>
+                        ColonistGroupManager.SetGroup(pawn, groupId)));
+                }
+
+                Find.WindowStack.Add(new FloatMenu(options));
+            }
+
+            // Manage Groups button — opens GroupManagerWindow
+            Rect manageBtn = new Rect(inRect.width - 120f, currentY, 118f, 26f);
+            GUI.color = new Color(0.85f, 0.85f, 1f);
+            if (Widgets.ButtonText(manageBtn, "Manage Groups"))
+                Find.WindowStack.Add(new GroupManagerWindow());
+            GUI.color = Color.white;
+
+            currentY += 34f;
+
+            // Separator
+            Widgets.DrawBoxSolid(new Rect(0, currentY, inRect.width, 1f),
+                new Color(0.5f, 0.5f, 0.5f, 0.3f));
+            currentY += 6f;
         }
 
         private void DrawPromptSection(Rect inRect, ref float currentY)
         {
-            // ✅ TÍTULO DE SECCIÓN CON LÍNEA SEPARADORA
-            Rect promptTitleRect = new Rect(0, currentY, inRect.width, 25f);
-            Widgets.Label(promptTitleRect, "EchoColony.CustomPromptTitle".Translate());
+            Widgets.Label(new Rect(0, currentY, inRect.width, 25f),
+                "EchoColony.CustomPromptTitle".Translate());
             currentY += 30f;
 
-            // Línea separadora sutil
-            Rect separatorRect = new Rect(0, currentY - 5f, inRect.width, 1f);
-            Widgets.DrawBoxSolid(separatorRect, new Color(0.5f, 0.5f, 0.5f, 0.3f));
+            Widgets.DrawBoxSolid(new Rect(0, currentY - 5f, inRect.width, 1f),
+                new Color(0.5f, 0.5f, 0.5f, 0.3f));
 
-            // ✅ CHECKBOX MOVIDO AQUÍ - mejor ubicación contextual
-            Rect ageToggleLabel = new Rect(0f, currentY, 250f, 25f);
-            Widgets.Label(ageToggleLabel, "EchoColony.IgnoreAgeLabel".Translate());
-
+            // Age ignore checkbox
+            Widgets.Label(new Rect(0f, currentY, 250f, 25f),
+                "EchoColony.IgnoreAgeLabel".Translate());
             Rect ageToggle = new Rect(260f, currentY + 2f, 24f, 24f);
             bool currentValue = ColonistPromptManager.GetIgnoreAge(pawn);
-            bool tempValue = currentValue;
+            bool tempValue    = currentValue;
             Widgets.Checkbox(ageToggle.position, ref tempValue);
             if (tempValue != currentValue)
-            {
                 ColonistPromptManager.SetIgnoreAge(pawn, tempValue);
-            }
-            TooltipHandler.TipRegion(new Rect(0f, currentY, 300f, 25f), "EchoColony.IgnoreAgeTooltip".Translate());
+            TooltipHandler.TipRegion(new Rect(0f, currentY, 300f, 25f),
+                "EchoColony.IgnoreAgeTooltip".Translate());
 
-            currentY += 35f; // Espacio después del checkbox
+            currentY += 35f;
 
-            // ✅ ÁREA DE TEXTO CORREGIDA CON SCROLL FUNCIONAL
-            float buttonHeight = 30f;
-            float padding = 10f;
-            float textAreaTop = currentY;
-            float textHeight = inRect.height - textAreaTop - buttonHeight - padding;
+            // Prompt textarea — fills remaining space above save button
+            const float buttonHeight = 30f;
+            const float padding      = 10f;
+            float textHeight = inRect.height - currentY - buttonHeight - padding;
 
-            Rect scrollOuterRect = new Rect(0, textAreaTop, inRect.width, textHeight);
-
-            // Fondo negro y borde blanco
+            Rect scrollOuterRect = new Rect(0, currentY, inRect.width, textHeight);
             Widgets.DrawBoxSolid(scrollOuterRect, Color.black);
             Widgets.DrawBox(scrollOuterRect);
 
             Rect scrollViewRect = scrollOuterRect.ContractedBy(4f);
+            float textWidth     = scrollViewRect.width - 16f;
 
-            // ✅ CALCULAR ALTURA CORRECTA DEL CONTENIDO
-            float textWidth = scrollViewRect.width - 16f; // Espacio para scrollbar
-            
-            // Usar una altura mínima que permita scroll
-            float minHeight = scrollViewRect.height;
-            
-            // Calcular altura real del texto
-            GUIStyle tempStyle = new GUIStyle(GUI.skin.textArea);
-            tempStyle.wordWrap = true;
-            tempStyle.fontSize = 14;
-            tempStyle.padding = new RectOffset(6, 6, 6, 6);
-            
+            GUIStyle tempStyle = new GUIStyle(GUI.skin.textArea)
+            {
+                wordWrap = true,
+                fontSize = 14,
+                padding  = new RectOffset(6, 6, 6, 6),
+            };
             float textContentHeight = tempStyle.CalcHeight(new GUIContent(tempPrompt), textWidth);
-            
-            // Asegurar que siempre haya scroll disponible
-            float contentHeight = Mathf.Max(textContentHeight + 40f, minHeight + 50f);
-
-            Rect viewRect = new Rect(0f, 0f, textWidth, contentHeight);
+            float contentHeight     = Mathf.Max(textContentHeight + 40f, scrollViewRect.height + 50f);
+            Rect viewRect           = new Rect(0f, 0f, textWidth, contentHeight);
 
             Widgets.BeginScrollView(scrollViewRect, ref scroll, viewRect);
 
-            // ✅ TEXTAREA CON TAMAÑO CORRECTO
-            Rect textAreaRect = new Rect(0f, 0f, textWidth, contentHeight - 20f);
+            GUIStyle style = new GUIStyle(GUI.skin.textArea)
+            {
+                wordWrap         = true,
+                normal           = { textColor = Color.white },
+                padding          = new RectOffset(6, 6, 6, 6),
+                fontSize         = 14,
+            };
             GUI.SetNextControlName("PromptTextArea");
-
-            GUIStyle style = new GUIStyle(GUI.skin.textArea);
-            style.wordWrap = true;
-            style.normal.textColor = Color.white;
-            style.padding = new RectOffset(6, 6, 6, 6);
-            style.fontSize = 14;
-
-            tempPrompt = GUI.TextArea(textAreaRect, tempPrompt, style);
+            tempPrompt = GUI.TextArea(new Rect(0f, 0f, textWidth, contentHeight - 20f), tempPrompt, style);
 
             Widgets.EndScrollView();
 
-            // Enfocar el área de texto al abrir la ventana
             if (!hasFocused && Event.current.type == EventType.Layout)
             {
                 GUI.FocusControl("PromptTextArea");
@@ -255,15 +283,15 @@ namespace EchoColony
 
         private void DrawSaveButton(Rect inRect)
         {
-            // ✅ BOTÓN DE GUARDAR CON MEJOR ESTILO
-            float buttonHeight = 30f;
+            const float buttonHeight = 30f;
             Rect saveButtonRect = new Rect(inRect.width - 100f, inRect.height - buttonHeight, 100f, buttonHeight);
-            
-            GUI.color = new Color(0.8f, 1f, 0.8f); // Verde claro
+
+            GUI.color = new Color(0.8f, 1f, 0.8f);
             if (Widgets.ButtonText(saveButtonRect, "EchoColony.SaveButton".Translate()))
             {
                 ColonistPromptManager.SetPrompt(pawn, tempPrompt);
-                Messages.Message("EchoColony.ConfigurationSaved".Translate(pawn.LabelShort), MessageTypeDefOf.TaskCompletion);
+                Messages.Message("EchoColony.ConfigurationSaved".Translate(pawn.LabelShort),
+                    MessageTypeDefOf.TaskCompletion);
                 Close();
             }
             GUI.color = Color.white;
@@ -273,36 +301,29 @@ namespace EchoColony
         {
             if (Player2CharacterCache.Characters.Count == 0)
             {
-                // No hay personajes - mostrar advertencia
                 Messages.Message("EchoColony.NoCharactersFound".Translate(),
-                                MessageTypeDefOf.RejectInput, false);
+                    MessageTypeDefOf.RejectInput, false);
             }
             else if (Player2CharacterCache.Characters.Count == 1)
             {
-                // Solo un personaje - importar automáticamente
                 var character = Player2CharacterCache.Characters[0];
-
-                // Aplicar descripción y voz
                 tempPrompt = character.description;
                 if (!string.IsNullOrEmpty(character.voice_id))
                 {
                     ChatGameComponent.Instance.SetVoiceForPawn(pawn, character.voice_id);
                     ColonistVoiceManager.SetVoice(pawn, character.voice_id);
                 }
-
                 Messages.Message("EchoColony.CharacterImportedAuto".Translate(character.short_name),
-                                MessageTypeDefOf.TaskCompletion, false);
+                    MessageTypeDefOf.TaskCompletion, false);
             }
             else
             {
-                // Múltiples personajes - mostrar menú de selección
-                List<FloatMenuOption> options = new List<FloatMenuOption>();
+                var options = new List<FloatMenuOption>();
                 foreach (var character in Player2CharacterCache.Characters)
                 {
                     string label = $"{character.short_name} ({character.voice_id?.Substring(0, 6) ?? "No voice"})";
                     options.Add(new FloatMenuOption(label, () =>
                     {
-                        // Aplicar descripción y voz
                         tempPrompt = character.description;
                         if (!string.IsNullOrEmpty(character.voice_id))
                         {
@@ -310,7 +331,7 @@ namespace EchoColony
                             ColonistVoiceManager.SetVoice(pawn, character.voice_id);
                         }
                         Messages.Message("EchoColony.CharacterImported".Translate(character.short_name),
-                                        MessageTypeDefOf.TaskCompletion, false);
+                            MessageTypeDefOf.TaskCompletion, false);
                     }));
                 }
                 Find.WindowStack.Add(new FloatMenu(options));

--- a/source/GroupPrompt/ColonistGroup.cs
+++ b/source/GroupPrompt/ColonistGroup.cs
@@ -1,0 +1,36 @@
+using System;
+using UnityEngine;
+using Verse;
+
+namespace EchoColony
+{
+    /// <summary>
+    /// Represents a named group of colonists that share a common prompt.
+    /// Stored in PromptStorageComponent and keyed by a GUID string id.
+    /// </summary>
+    public class ColonistGroup : IExposable
+    {
+        public string id = "";
+        public string name = "";
+        public string prompt = "";
+        public Color color = Color.white;
+
+        public ColonistGroup() { }
+
+        public ColonistGroup(string name, string prompt, Color color)
+        {
+            this.id = Guid.NewGuid().ToString();
+            this.name = name;
+            this.prompt = prompt;
+            this.color = color;
+        }
+
+        public void ExposeData()
+        {
+            Scribe_Values.Look(ref id, "id", "");
+            Scribe_Values.Look(ref name, "name", "");
+            Scribe_Values.Look(ref prompt, "prompt", "");
+            Scribe_Values.Look(ref color, "color", Color.white);
+        }
+    }
+}

--- a/source/GroupPrompt/ColonistGroupManager.cs
+++ b/source/GroupPrompt/ColonistGroupManager.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Verse;
+
+namespace EchoColony
+{
+    /// <summary>
+    /// Static helper for reading and writing colonist group assignments and group data.
+    /// Mirrors the ColonistPromptManager pattern — all persistence goes through PromptStorageComponent.
+    /// </summary>
+    public static class ColonistGroupManager
+    {
+        private static PromptStorageComponent Storage => Current.Game?.GetComponent<PromptStorageComponent>();
+
+        // ── Group retrieval ────────────────────────────────────────────────────
+
+        public static List<ColonistGroup> GetAllGroups()
+        {
+            return Storage?.groups.Values.ToList() ?? new List<ColonistGroup>();
+        }
+
+        public static ColonistGroup GetGroupById(string groupId)
+        {
+            if (string.IsNullOrWhiteSpace(groupId)) return null;
+            var storage = Storage;
+            if (storage == null) return null;
+            storage.groups.TryGetValue(groupId, out ColonistGroup group);
+            return group;
+        }
+
+        // ── Per-colonist group assignment ──────────────────────────────────────
+
+        public static ColonistGroup GetGroup(Pawn pawn)
+        {
+            var storage = Storage;
+            if (storage == null || pawn == null) return null;
+            if (!storage.groupByColonist.TryGetValue(pawn.ThingID, out string groupId)) return null;
+            storage.groups.TryGetValue(groupId, out ColonistGroup group);
+            return group;
+        }
+
+        public static string GetGroupPrompt(Pawn pawn)
+        {
+            return GetGroup(pawn)?.prompt ?? "";
+        }
+
+        public static void SetGroup(Pawn pawn, string groupId)
+        {
+            var storage = Storage;
+            if (storage == null || pawn == null) return;
+
+            if (string.IsNullOrWhiteSpace(groupId))
+                storage.groupByColonist.Remove(pawn.ThingID);
+            else
+                storage.groupByColonist[pawn.ThingID] = groupId;
+        }
+
+        public static void ClearGroup(Pawn pawn)
+        {
+            if (pawn == null) return;
+            Storage?.groupByColonist.Remove(pawn.ThingID);
+        }
+
+        // ── Group CRUD ─────────────────────────────────────────────────────────
+
+        public static ColonistGroup CreateGroup(string name, string prompt, Color color)
+        {
+            var storage = Storage;
+            if (storage == null) return null;
+
+            var group = new ColonistGroup(name, prompt, color);
+            storage.groups[group.id] = group;
+            return group;
+        }
+
+        public static void UpdateGroup(string id, string name, string prompt, Color color)
+        {
+            var storage = Storage;
+            if (storage == null || !storage.groups.ContainsKey(id)) return;
+
+            storage.groups[id].name = name;
+            storage.groups[id].prompt = prompt;
+            storage.groups[id].color = color;
+        }
+
+        public static void DeleteGroup(string id)
+        {
+            var storage = Storage;
+            if (storage == null) return;
+
+            storage.groups.Remove(id);
+
+            // Remove all colonist assignments pointing to this group
+            var toRemove = storage.groupByColonist
+                .Where(kvp => kvp.Value == id)
+                .Select(kvp => kvp.Key)
+                .ToList();
+
+            foreach (var key in toRemove)
+                storage.groupByColonist.Remove(key);
+        }
+    }
+}

--- a/source/GroupPrompt/GroupManagerWindow.cs
+++ b/source/GroupPrompt/GroupManagerWindow.cs
@@ -1,0 +1,328 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Verse;
+using RimWorld;
+
+namespace EchoColony
+{
+    /// <summary>
+    /// Full-screen window for creating, editing, and deleting colonist groups.
+    /// Two-panel layout: group list on the left, editor on the right.
+    /// </summary>
+    public class GroupManagerWindow : Window
+    {
+        private ColonistGroup selectedGroup;
+
+        // Editor fields — hold temporary edits before saving
+        private string editName   = "";
+        private string editPrompt = "";
+        private Color  editColor  = Color.white;
+
+        private Vector2 groupListScroll;
+        private Vector2 colonistListScroll;
+        private Vector2 promptScroll;
+
+        private List<Pawn> allColonists = new List<Pawn>();
+
+        private static readonly Color[] PresetColors =
+        {
+            new Color(0.85f, 0.35f, 0.35f), // Red
+            new Color(0.35f, 0.80f, 0.45f), // Green
+            new Color(0.35f, 0.55f, 0.90f), // Blue
+            new Color(0.90f, 0.85f, 0.35f), // Yellow
+            new Color(0.90f, 0.58f, 0.30f), // Orange
+            new Color(0.65f, 0.35f, 0.90f), // Purple
+            new Color(0.35f, 0.85f, 0.85f), // Cyan
+            new Color(0.90f, 0.35f, 0.70f), // Pink
+        };
+
+        public GroupManagerWindow()
+        {
+            this.doCloseX         = true;
+            this.forcePause       = true;
+            this.absorbInputAroundWindow = true;
+            this.closeOnAccept    = false;
+            this.closeOnCancel    = true;
+            this.draggable        = true;
+
+            RefreshColonists();
+        }
+
+        private void RefreshColonists()
+        {
+            allColonists = Find.Maps
+                .SelectMany(m => m.mapPawns.FreeColonistsSpawned)
+                .OrderBy(p => p.LabelShort)
+                .ToList();
+        }
+
+        public override Vector2 InitialSize => new Vector2(760f, 620f);
+
+        public override void DoWindowContents(Rect inRect)
+        {
+            // Title
+            Text.Font = GameFont.Medium;
+            Widgets.Label(new Rect(0f, 0f, inRect.width, 35f), "Group Prompts");
+            Text.Font = GameFont.Small;
+
+            const float leftWidth = 185f;
+            const float spacing   = 12f;
+            float panelY = 42f;
+
+            Rect leftRect  = new Rect(0f,                  panelY, leftWidth,                      inRect.height - panelY);
+            Rect divider   = new Rect(leftWidth + 1f,      panelY, 1f,                             inRect.height - panelY);
+            Rect rightRect = new Rect(leftWidth + spacing,  panelY, inRect.width - leftWidth - spacing, inRect.height - panelY);
+
+            // Subtle vertical divider
+            Widgets.DrawBoxSolid(divider, new Color(0.4f, 0.4f, 0.4f, 0.5f));
+
+            DrawLeftPanel(leftRect);
+            DrawRightPanel(rightRect);
+        }
+
+        // ── Left panel: group list + New Group button ──────────────────────────
+
+        private void DrawLeftPanel(Rect rect)
+        {
+            const float newBtnHeight = 32f;
+            const float btnSpacing   = 6f;
+
+            Rect listRect   = new Rect(rect.x, rect.y, rect.width, rect.height - newBtnHeight - btnSpacing);
+            Rect newBtnRect = new Rect(rect.x, listRect.yMax + btnSpacing, rect.width, newBtnHeight);
+
+            DrawGroupList(listRect);
+
+            GUI.color = new Color(0.75f, 1f, 0.75f);
+            if (Widgets.ButtonText(newBtnRect, "+ New Group"))
+            {
+                var existing = ColonistGroupManager.GetAllGroups();
+                var color    = PresetColors[existing.Count % PresetColors.Length];
+                var newGroup = ColonistGroupManager.CreateGroup("New Group", "", color);
+                SelectGroup(newGroup);
+            }
+            GUI.color = Color.white;
+        }
+
+        private void DrawGroupList(Rect rect)
+        {
+            var groups      = ColonistGroupManager.GetAllGroups();
+            float rowHeight = 38f;
+            float viewH     = Mathf.Max(groups.Count * rowHeight, rect.height);
+
+            Rect viewRect = new Rect(0f, 0f, rect.width - 16f, viewH);
+            Widgets.BeginScrollView(rect, ref groupListScroll, viewRect);
+
+            float rowY = 0f;
+            foreach (var group in groups)
+            {
+                Rect row = new Rect(0f, rowY, viewRect.width, rowHeight - 2f);
+                bool selected = selectedGroup?.id == group.id;
+
+                if (selected)
+                    Widgets.DrawHighlight(row);
+                else if (Mouse.IsOver(row))
+                    Widgets.DrawLightHighlight(row);
+
+                // Color dot
+                Rect dot = new Rect(row.x + 6f, row.y + (row.height - 16f) / 2f, 16f, 16f);
+                Widgets.DrawBoxSolid(dot, group.color);
+                Widgets.DrawBox(dot);
+
+                // Group name
+                Text.Anchor = TextAnchor.MiddleLeft;
+                Widgets.Label(new Rect(dot.xMax + 8f, row.y, row.width - dot.xMax - 10f, row.height), group.name);
+                Text.Anchor = TextAnchor.UpperLeft;
+
+                if (Widgets.ButtonInvisible(row))
+                    SelectGroup(group);
+
+                rowY += rowHeight;
+            }
+
+            Widgets.EndScrollView();
+        }
+
+        // ── Right panel: group editor ──────────────────────────────────────────
+
+        private void DrawRightPanel(Rect rect)
+        {
+            if (selectedGroup == null)
+            {
+                Text.Anchor = TextAnchor.MiddleCenter;
+                GUI.color   = Color.gray;
+                Widgets.Label(rect, "Select a group or create a new one.");
+                GUI.color   = Color.white;
+                Text.Anchor = TextAnchor.UpperLeft;
+                return;
+            }
+
+            float curY = rect.y;
+
+            // Name
+            curY = DrawLabeledField(rect, curY, "Name", 55f, (fieldRect) =>
+            {
+                editName = Widgets.TextField(fieldRect, editName);
+            }, 28f);
+
+            // Color picker
+            Widgets.Label(new Rect(rect.x, curY, 55f, 26f), "Color");
+            float colorX = rect.x + 60f;
+            foreach (var c in PresetColors)
+            {
+                Rect dot = new Rect(colorX, curY + 3f, 22f, 22f);
+                Widgets.DrawBoxSolid(dot, c);
+                if (editColor == c)
+                    Widgets.DrawBox(dot, 2);
+                if (Widgets.ButtonInvisible(dot))
+                    editColor = c;
+                colorX += 28f;
+            }
+            curY += 32f;
+
+            // Prompt textarea
+            Widgets.Label(new Rect(rect.x, curY, rect.width, 20f), "Group Prompt:");
+            curY += 22f;
+
+            const float colonistSectionH = 150f;
+            const float saveRowH         = 36f;
+            const float sectionSpacing   = 8f;
+            float promptH = rect.height - (curY - rect.y) - colonistSectionH - saveRowH - sectionSpacing * 2f;
+
+            DrawPromptArea(new Rect(rect.x, curY, rect.width, promptH));
+            curY += promptH + sectionSpacing;
+
+            // Colonist assignment
+            Widgets.Label(new Rect(rect.x, curY, rect.width, 20f), "Assigned colonists:");
+            curY += 22f;
+
+            DrawColonistAssignment(new Rect(rect.x, curY, rect.width, colonistSectionH - 22f));
+            curY += colonistSectionH - 22f + sectionSpacing;
+
+            // Save / Delete
+            DrawSaveDeleteRow(new Rect(rect.x, curY, rect.width, saveRowH));
+        }
+
+        private float DrawLabeledField(Rect rect, float curY, string label, float labelWidth, System.Action<Rect> fieldDrawer, float rowHeight)
+        {
+            Widgets.Label(new Rect(rect.x, curY, labelWidth, rowHeight), label);
+            fieldDrawer(new Rect(rect.x + labelWidth + 5f, curY, rect.width - labelWidth - 5f, rowHeight - 2f));
+            return curY + rowHeight;
+        }
+
+        private void DrawPromptArea(Rect outer)
+        {
+            Widgets.DrawBoxSolid(outer, Color.black);
+            Widgets.DrawBox(outer);
+
+            Rect inner     = outer.ContractedBy(4f);
+            float txtWidth = inner.width - 16f;
+
+            GUIStyle style = new GUIStyle(GUI.skin.textArea)
+            {
+                wordWrap         = true,
+                fontSize         = 14,
+                normal           = { textColor = Color.white },
+                padding          = new RectOffset(5, 5, 5, 5),
+            };
+
+            float textH   = style.CalcHeight(new GUIContent(editPrompt), txtWidth);
+            float viewH   = Mathf.Max(textH + 20f, inner.height + 20f);
+            Rect viewRect = new Rect(0f, 0f, txtWidth, viewH);
+
+            Widgets.BeginScrollView(inner, ref promptScroll, viewRect);
+            editPrompt = GUI.TextArea(new Rect(0f, 0f, txtWidth, viewH - 8f), editPrompt, style);
+            Widgets.EndScrollView();
+        }
+
+        private void DrawColonistAssignment(Rect outer)
+        {
+            float rowH    = 26f;
+            float viewH   = Mathf.Max(allColonists.Count * rowH, outer.height);
+            Rect viewRect = new Rect(0f, 0f, outer.width - 16f, viewH);
+
+            Widgets.BeginScrollView(outer, ref colonistListScroll, viewRect);
+
+            float rowY = 0f;
+            foreach (var pawn in allColonists)
+            {
+                Rect row           = new Rect(0f, rowY, viewRect.width, rowH - 2f);
+                var  currentGroup  = ColonistGroupManager.GetGroup(pawn);
+                bool isInThisGroup = currentGroup?.id == selectedGroup.id;
+                bool toggle        = isInThisGroup;
+
+                Widgets.Checkbox(new Vector2(row.x, row.y + (row.height - 24f) / 2f), ref toggle);
+
+                // Label — gray if in another group
+                string label = pawn.LabelShort;
+                if (currentGroup != null && !isInThisGroup)
+                {
+                    GUI.color = Color.gray;
+                    label    += $"  (in {currentGroup.name})";
+                }
+
+                Text.Anchor = TextAnchor.MiddleLeft;
+                Widgets.Label(new Rect(row.x + 28f, row.y, row.width - 28f, row.height), label);
+                Text.Anchor = TextAnchor.UpperLeft;
+                GUI.color   = Color.white;
+
+                // Apply assignment change
+                if (toggle != isInThisGroup)
+                {
+                    if (toggle)
+                        ColonistGroupManager.SetGroup(pawn, selectedGroup.id);
+                    else
+                        ColonistGroupManager.ClearGroup(pawn);
+                }
+
+                rowY += rowH;
+            }
+
+            Widgets.EndScrollView();
+        }
+
+        private void DrawSaveDeleteRow(Rect rect)
+        {
+            const float btnW    = 100f;
+            const float spacing = 10f;
+
+            GUI.color = new Color(0.75f, 1f, 0.75f);
+            if (Widgets.ButtonText(new Rect(rect.x, rect.y, btnW, rect.height), "Save"))
+            {
+                ColonistGroupManager.UpdateGroup(selectedGroup.id, editName, editPrompt, editColor);
+                selectedGroup.name   = editName;
+                selectedGroup.prompt = editPrompt;
+                selectedGroup.color  = editColor;
+                Messages.Message($"Group '{editName}' saved.", MessageTypeDefOf.TaskCompletion);
+            }
+            GUI.color = Color.white;
+
+            GUI.color = new Color(1f, 0.55f, 0.55f);
+            if (Widgets.ButtonText(new Rect(rect.x + btnW + spacing, rect.y, btnW, rect.height), "Delete Group"))
+            {
+                string groupName = selectedGroup.name;
+                Find.WindowStack.Add(Dialog_MessageBox.CreateConfirmation(
+                    $"Delete group '{groupName}'? All colonist assignments will be removed.",
+                    () =>
+                    {
+                        ColonistGroupManager.DeleteGroup(selectedGroup.id);
+                        selectedGroup = null;
+                        editName      = "";
+                        editPrompt    = "";
+                        editColor     = Color.white;
+                    }
+                ));
+            }
+            GUI.color = Color.white;
+        }
+
+        private void SelectGroup(ColonistGroup group)
+        {
+            selectedGroup = group;
+            editName      = group.name;
+            editPrompt    = group.prompt;
+            editColor     = group.color;
+            promptScroll  = Vector2.zero;
+        }
+    }
+}

--- a/source/PromptStorageComponent.cs
+++ b/source/PromptStorageComponent.cs
@@ -7,78 +7,105 @@ namespace EchoColony
 {
     public class PromptStorageComponent : GameComponent
     {
-        public Dictionary<string, string> promptsByColonist = new Dictionary<string, string>();
-        public Dictionary<string, string> voicesByColonist = new Dictionary<string, string>();
+        // Per-colonist individual prompts and settings, keyed by ThingID
+        public Dictionary<string, string> promptsByColonist  = new Dictionary<string, string>();
+        public Dictionary<string, string> voicesByColonist   = new Dictionary<string, string>();
+        public Dictionary<string, bool>   ignoreAgeByColonist = new Dictionary<string, bool>();
 
-        public Dictionary<string, bool> ignoreAgeByColonist = new Dictionary<string, bool>();
-
+        // Group system — groups keyed by group GUID id, assignments keyed by colonist ThingID
+        public Dictionary<string, ColonistGroup> groups           = new Dictionary<string, ColonistGroup>();
+        public Dictionary<string, string>         groupByColonist  = new Dictionary<string, string>();
 
         public PromptStorageComponent(Game game)
         {
-            // 🔒 Seguridad por si RimWorld no llama ExposeData correctamente
-            if (promptsByColonist == null)
-                promptsByColonist = new Dictionary<string, string>();
-
-            if (voicesByColonist == null)
-                voicesByColonist = new Dictionary<string, string>();
+            EnsureDictionaries();
         }
 
         public override void ExposeData()
         {
             base.ExposeData();
 
-            Scribe_Collections.Look(ref promptsByColonist, "promptsByColonist", LookMode.Value, LookMode.Value);
-            Scribe_Collections.Look(ref voicesByColonist, "voicesByColonist", LookMode.Value, LookMode.Value);
+            Scribe_Collections.Look(ref promptsByColonist,   "promptsByColonist",   LookMode.Value, LookMode.Value);
+            Scribe_Collections.Look(ref voicesByColonist,    "voicesByColonist",    LookMode.Value, LookMode.Value);
             Scribe_Collections.Look(ref ignoreAgeByColonist, "ignoreAgeByColonist", LookMode.Value, LookMode.Value);
+            Scribe_Collections.Look(ref groups,              "groups",              LookMode.Value, LookMode.Deep);
+            Scribe_Collections.Look(ref groupByColonist,     "groupByColonist",     LookMode.Value, LookMode.Value);
 
-            if (ignoreAgeByColonist == null)
-                ignoreAgeByColonist = new Dictionary<string, bool>();
-
-            // 🔁 Revalidar después de cargar
-            if (promptsByColonist == null)
-                promptsByColonist = new Dictionary<string, string>();
-
-            if (voicesByColonist == null)
-                voicesByColonist = new Dictionary<string, string>();
-        }
-
-        public void CleanupOrphanedPrompts()
-        {
-            // Verificamos que los diccionarios no sean nulos antes de empezar
-            if (promptsByColonist == null) return;
-
-            // PawnsFinder requiere System.Linq para el .Select y .Where
-            var validPawnIDs = new HashSet<string>(
-                PawnsFinder.AllMapsWorldAndTemporary_AliveOrDead
-                    .Where(p => p != null)
-                    .Select(p => p.ThingID)
-            );
-
-            List<string> keysToRemove = promptsByColonist.Keys
-                .Where(key => !validPawnIDs.Contains(key))
-                .ToList();
-
-            foreach (var key in keysToRemove)
-            {
-                promptsByColonist.Remove(key);
-                voicesByColonist?.Remove(key);
-                ignoreAgeByColonist?.Remove(key);
-                Log.Message($"[EchoColony] Cleaned up data for obsolete Pawn ID: {key}");
-            }
+            if (Scribe.mode == LoadSaveMode.LoadingVars)
+                EnsureDictionaries();
         }
 
         public override void FinalizeInit()
         {
             base.FinalizeInit();
 
-            CleanupOrphanedPrompts();
+            CleanupOrphanedData();
 
-            // 🔁 Agregar TTSVoiceLoaderComponent si no está
             if (Current.Game.GetComponent<TTSVoiceLoaderComponent>() == null)
             {
                 Current.Game.components.Add(new TTSVoiceLoaderComponent(Current.Game));
-                Log.Message("[EchoColony] 🔁 TTSVoiceLoaderComponent agregado desde PromptStorageComponent");
+                Log.Message("[EchoColony] TTSVoiceLoaderComponent added from PromptStorageComponent");
             }
+        }
+
+        /// <summary>
+        /// Removes data for colonists that no longer exist in any form.
+        /// Also removes group assignments pointing to deleted groups.
+        /// </summary>
+        public void CleanupOrphanedData()
+        {
+            if (promptsByColonist == null) return;
+
+            var validPawnIDs = new HashSet<string>(
+                PawnsFinder.AllMapsWorldAndTemporary_AliveOrDead
+                    .Where(p => p != null)
+                    .Select(p => p.ThingID)
+            );
+
+            // Clean per-colonist data for dead/missing pawns
+            var deadKeys = promptsByColonist.Keys
+                .Where(k => !validPawnIDs.Contains(k))
+                .ToList();
+
+            foreach (var key in deadKeys)
+            {
+                promptsByColonist.Remove(key);
+                voicesByColonist?.Remove(key);
+                ignoreAgeByColonist?.Remove(key);
+                groupByColonist?.Remove(key);
+                Log.Message($"[EchoColony] Cleaned up data for obsolete Pawn ID: {key}");
+            }
+
+            // Clean group assignments pointing to groups that no longer exist
+            if (groupByColonist != null && groups != null)
+            {
+                var orphanedAssignments = groupByColonist
+                    .Where(kvp => !groups.ContainsKey(kvp.Value))
+                    .Select(kvp => kvp.Key)
+                    .ToList();
+
+                foreach (var key in orphanedAssignments)
+                    groupByColonist.Remove(key);
+            }
+
+            // Clean groupByColonist for pawns that have a group but no individual prompt
+            if (groupByColonist != null)
+            {
+                var deadGroupKeys = groupByColonist.Keys
+                    .Where(k => !validPawnIDs.Contains(k))
+                    .ToList();
+                foreach (var key in deadGroupKeys)
+                    groupByColonist.Remove(key);
+            }
+        }
+
+        private void EnsureDictionaries()
+        {
+            if (promptsByColonist  == null) promptsByColonist  = new Dictionary<string, string>();
+            if (voicesByColonist   == null) voicesByColonist   = new Dictionary<string, string>();
+            if (ignoreAgeByColonist == null) ignoreAgeByColonist = new Dictionary<string, bool>();
+            if (groups             == null) groups             = new Dictionary<string, ColonistGroup>();
+            if (groupByColonist    == null) groupByColonist    = new Dictionary<string, string>();
         }
     }
 }

--- a/source/player2/Player2Importer.cs
+++ b/source/player2/Player2Importer.cs
@@ -21,7 +21,7 @@ namespace EchoColony
 
         if (request.isNetworkError || request.isHttpError)
         {
-            Log.Warning("[EchoColony] Failed to fetch Player2 characters: " + request.error);
+            Log.Message("[EchoColony] Failed to fetch Player2 characters: " + request.error);
             yield break;
         }
         try


### PR DESCRIPTION
- Added ColonistGroup data model with name, prompt, and color
- Added ColonistGroupManager static helper for group CRUD operations
- Added GroupManagerWindow for creating, editing, and deleting groups
- Updated PromptStorageComponent to persist group data and assignments
- Updated ColonistPromptEditor to show current group assignment with colored tag, Change button, and Manage Groups button
- Group prompts inject between global and individual prompts in ColonistPromptContextBuilder
- Orphaned group data is cleaned up automatically on save load