### PR TITLE
Group Manage change, KickedOut removed

### DIFF
--- a/1.6/Languages/English/Keyed/EchoColony.xml
+++ b/1.6/Languages/English/Keyed/EchoColony.xml
@@ -101,7 +101,8 @@
   <EchoColony.GCWModeArea>Area</EchoColony.GCWModeArea>
   <EchoColony.GCWModeMap>Map</EchoColony.GCWModeMap>
   <EchoColony.GCWReAdd>Re-Add</EchoColony.GCWReAdd>
-  <EchoColony.GCWAdd>Add</EchoColony.GCWAdd>																	 
+  <EchoColony.GCWAdd>Add</EchoColony.GCWAdd>
+  <EchoColony.GCWSend>Send</EchoColony.GCWSend>
   
   <!-- ===== PROMPT EDITOR ===== -->
   <EchoColony.PersonalizingTitle>Customizing: {0}</EchoColony.PersonalizingTitle>

--- a/1.6/Languages/English/Keyed/EchoColony.xml
+++ b/1.6/Languages/English/Keyed/EchoColony.xml
@@ -96,6 +96,12 @@
   <EchoColony.GCWManagerKickedOut>Previously removed: ({0})</EchoColony.GCWManagerKickedOut>
   <EchoColony.GCWClearMessage>Are you sure you want to clear the entire chat history?</EchoColony.GCWClearMessage>
   <EchoColony.GCWClearConfirmation>Chat cleared</EchoColony.GCWClearConfirmation>
+  <EchoColony.GCWSelectMode>Selection mode</EchoColony.GCWSelectMode>
+  <EchoColony.GCWModeRoom>Room</EchoColony.GCWModeRoom>
+  <EchoColony.GCWModeArea>Area</EchoColony.GCWModeArea>
+  <EchoColony.GCWModeMap>Map</EchoColony.GCWModeMap>
+  <EchoColony.GCWReAdd>Re-Add</EchoColony.GCWReAdd>
+  <EchoColony.GCWAdd>Add</EchoColony.GCWAdd>																	 
   
   <!-- ===== PROMPT EDITOR ===== -->
   <EchoColony.PersonalizingTitle>Customizing: {0}</EchoColony.PersonalizingTitle>

--- a/1.6/Languages/Spanish/Keyed/EchoColony.xml
+++ b/1.6/Languages/Spanish/Keyed/EchoColony.xml
@@ -101,7 +101,8 @@
   <EchoColony.GCWModeArea>Area</EchoColony.GCWModeArea>
   <EchoColony.GCWModeMap>Mapa</EchoColony.GCWModeMap>
   <EchoColony.GCWReAdd>Retornar</EchoColony.GCWReAdd>
-  <EchoColony.GCWAdd>Añadir</EchoColony.GCWAdd>																		 
+  <EchoColony.GCWAdd>Añadir</EchoColony.GCWAdd>
+  <EchoColony.GCWSend>Enviar</EchoColony.GCWSend>  
   
 
   <!-- ===== EDITOR DE PROMPT ===== -->

--- a/1.6/Languages/Spanish/Keyed/EchoColony.xml
+++ b/1.6/Languages/Spanish/Keyed/EchoColony.xml
@@ -96,6 +96,12 @@
   <EchoColony.GCWManagerKickedOut>Previamente quitados: ({0})</EchoColony.GCWManagerKickedOut>
   <EchoColony.GCWClearMessage>¿Estás seguro de que quieres borrar todo el historial de chat?</EchoColony.GCWClearMessage>
   <EchoColony.GCWClearConfirmation>Chat borrado</EchoColony.GCWClearConfirmation>  
+  <EchoColony.GCWSelectMode>Modo de selección</EchoColony.GCWSelectMode>
+  <EchoColony.GCWModeRoom>Sala</EchoColony.GCWModeRoom>
+  <EchoColony.GCWModeArea>Area</EchoColony.GCWModeArea>
+  <EchoColony.GCWModeMap>Mapa</EchoColony.GCWModeMap>
+  <EchoColony.GCWReAdd>Retornar</EchoColony.GCWReAdd>
+  <EchoColony.GCWAdd>Añadir</EchoColony.GCWAdd>																		 
   
 
   <!-- ===== EDITOR DE PROMPT ===== -->

--- a/source/Patch_ChatGizmo.cs
+++ b/source/Patch_ChatGizmo.cs
@@ -33,27 +33,34 @@ namespace EchoColony
             {
                 var selectedForGroup = Find.Selector.SelectedObjects
                     .OfType<Pawn>()
-                    .Where(p => p != null && !p.Dead && p.Spawned && IsValidForGroupChat(p))
+                    .Where(p => IsValidForGroupChat(p)) //*furel* Simplified selection, IsValidForGruoupChat will check every thing.
                     .ToList();
-
+				//Individual Gizmos
                 if (Find.Selector.SingleSelectedThing == pawn && IsValidChatPawn(pawn))
                 {
                     extraGizmos.Add(CreateIndividualChatGizmo(pawn));
                     extraGizmos.Add(CreateQuickChatGizmo(pawn));
                 }
-
+				//-------- Group Gizmos ------------
                 if (IsGroupChatAllowedForCurrentModel())
                 {
+					//--------- Open Group Chat with Pawns selected --------------							
+					ColonistGroupChatWindow.GroupSelectionMode InitialMode = ColonistGroupChatWindow.GroupSelectionMode.Room; ;	//*furel* Group open menú selection. This is used to select the mode of group chat when is open.												   		 
                     if (selectedForGroup.Count > 1)
                     {
                         if (pawn == selectedForGroup[0])
-                            extraGizmos.Add(CreateGroupChatGizmo(pawn, selectedForGroup));
+							InitialMode = ColonistGroupChatWindow.GroupSelectionMode.MapWide; //*furel* If pawns are selected the Group Chat opens in "Map" mode															 
+                            extraGizmos.Add(CreateGroupChatGizmo(pawn, selectedForGroup, InitialMode)); //*furel* Added a new imput when creating the chat Windows
                     }
+					//--------- Open Group Chat with one pawn selected --------------						 
                     else if (IsValidForGroupChat(pawn))
                     {
-                        var nearbyColonists = GetNearbyColonists(pawn);
+						//*furel* New way to select participansts. GetNearbyColonists is deprecated.
+                        var nearbyColonists = new List<Pawn> ();
+                        nearbyColonists = ColonistGroupChatWindow.GetPawnsInRoom(pawn); //*furel* Getting the list of pawns with the new funtion.
+                        InitialMode = ColonistGroupChatWindow.GroupSelectionMode.Room;  //*furel* Open Group Chat Windos in Room mode.
                         if (nearbyColonists.Count >= 1)
-                            extraGizmos.Add(CreateGroupChatGizmo(pawn, nearbyColonists));
+                            extraGizmos.Add(CreateGroupChatGizmo(pawn, nearbyColonists, InitialMode)); //*furel* Added a new imput when creating the chat Windows
                     }
                 }
             }
@@ -106,40 +113,52 @@ namespace EchoColony
             }
         }
 
-        private static List<Pawn> GetNearbyColonists(Pawn pawn)
+		//*furel* No necessary any more with the method used now.																			
+        //private static List<Pawn> GetNearbyColonists(Pawn pawn)
+        //{
+        //    try
+        //    {
+        //        if (pawn?.Map == null) return new List<Pawn>();
+
+        //        var allPawns = pawn.Map.mapPawns?.AllPawnsSpawned;
+        //        if (allPawns == null) return new List<Pawn>();
+
+        //        return allPawns
+        //            .Where(p => p != null &&
+        //                        p != pawn &&
+        //                        !p.Dead &&
+        //                        !p.Destroyed &&
+        //                        p.RaceProps.Humanlike &&
+        //                        p.Spawned &&
+        //                        p.Position.IsValid &&
+        //                        pawn.Position.IsValid &&
+        //                        p.Position.InHorDistOf(pawn.Position, 10f) &&
+        //                        IsValidForGroupChat(p))
+        //            .ToList();
+        //    }
+        //    catch (Exception ex)
+        //    {
+        //        Log.Warning($"[EchoColony] Error getting nearby colonists for {pawn?.LabelShort}: {ex.Message}");
+        //        return new List<Pawn>();
+        //    }
+        //}
+
+		//*furel* Changed private to public so it can be used in ColonistGroupChatWindows.cs. It can be moved to a separate Utility.cs with other utility functions																		 
+        public static bool IsValidForGroupChat(Pawn pawn) 
         {
-            try
-            {
-                if (pawn?.Map == null) return new List<Pawn>();
+            //*furel* Added new filters to prevent assaign Chat Group for invalid pawns or animals
+            if (pawn == null || pawn.Dead || !pawn.Spawned || pawn.Destroyed || !pawn.RaceProps.Humanlike) 
+				return false;
 
-                var allPawns = pawn.Map.mapPawns?.AllPawnsSpawned;
-                if (allPawns == null) return new List<Pawn>();
+            if (pawn.IsPrisoner) 
+				return false;
 
-                return allPawns
-                    .Where(p => p != null &&
-                                p != pawn &&
-                                !p.Dead &&
-                                !p.Destroyed &&
-                                p.RaceProps.Humanlike &&
-                                p.Spawned &&
-                                p.Position.IsValid &&
-                                pawn.Position.IsValid &&
-                                p.Position.InHorDistOf(pawn.Position, 10f) &&
-                                IsValidForGroupChat(p))
-                    .ToList();
-            }
-            catch (Exception ex)
-            {
-                Log.Warning($"[EchoColony] Error getting nearby colonists for {pawn?.LabelShort}: {ex.Message}");
-                return new List<Pawn>();
-            }
-        }
+            if (pawn.Faction == Faction.OfPlayer && !pawn.IsSlave)
+                return true;
 
-        private static bool IsValidForGroupChat(Pawn pawn)
-        {
-            if (pawn.IsPrisoner) return false;
-            if (pawn.Faction == Faction.OfPlayer && !pawn.IsSlave) return true;
-            if (pawn.IsSlave && pawn.SlaveFaction == Faction.OfPlayer) return true;
+			if (pawn.IsSlaveOfColony)
+				return true;
+
             return false;
         }
 
@@ -230,8 +249,8 @@ namespace EchoColony
                 }
             };
         }
-
-        private static Command_Action CreateGroupChatGizmo(Pawn pawn, List<Pawn> nearbyColonists)
+		//*furel* Added open window mode as new variable entry so chat window can open, modes are defined in ColonistChatWindow.cs.
+        private static Command_Action CreateGroupChatGizmo(Pawn pawn, List<Pawn> nearbyColonists, ColonistGroupChatWindow.GroupSelectionMode mode)
         {
             return new Command_Action
             {
@@ -264,7 +283,7 @@ namespace EchoColony
                         }
 
                         validParticipants.Insert(0, pawn);
-                        Find.WindowStack.Add(new ColonistGroupChatWindow(validParticipants));
+                        Find.WindowStack.Add(new ColonistGroupChatWindow(validParticipants, mode)); 
                         Find.TickManager.CurTimeSpeed = TimeSpeed.Paused;
                     }
                     catch (Exception ex)

--- a/source/group/ColonistGroupChatWindow.cs
+++ b/source/group/ColonistGroupChatWindow.cs
@@ -1,6 +1,7 @@
 using UnityEngine;
 using Verse;
 using System.Collections.Generic;
+using Verse.Sound;				
 using System.Linq;
 using System.Collections;
 using RimWorld;
@@ -20,13 +21,23 @@ namespace EchoColony
         private bool        sendRequestedViaEnter = false;
         private bool        showParticipantManagement = false;
         private List<float> cachedHeights = new List<float>();
-        private Vector2 portraitsScrollPos = Vector2.zero; //*furel* new variable for portraits scroll
-
-        private HashSet<Pawn> KickedOut => session.KickedOutColonists;
+        private string lastMessageTextSeen = null; //*furel - hight calculation sistem* New variable for control.												  
+        private Vector2 portraitsScrollPos = Vector2.zero;
+        //private HashSet<Pawn> KickedOut => session.KickedOutColonists; *furel - Deleted Kickout list*
         private Pawn          initiator;
 
         private List<Pawn> availableColonists = new List<Pawn>();
+		
+//*furel - Mode group formation* New variable for tracking the whay groups are made.
+        public enum GroupSelectionMode
+        {
+            Room,       // Near colonist
+            Area,       // Area of 15 squares
+            MapWide     // All map
+        }
 
+        // Current mode (Room by default)
+        private GroupSelectionMode currentMode = GroupSelectionMode.Room;
         // Per-colonist color palette — distinct, readable on dark backgrounds
         private static readonly Color[] PawnColors = new Color[]
         {
@@ -48,25 +59,28 @@ namespace EchoColony
         private const float MAX_CHAT_DISTANCE     = 15f;
         private const float OUTDOOR_CHAT_DISTANCE = 8f;
 
-        public ColonistGroupChatWindow(List<Pawn> participants)
+        public ColonistGroupChatWindow(List<Pawn> participants, GroupSelectionMode initialMode) //*furel - Mode group formation* Added initialMode as variable imput.
         {
             this.initiator = participants.First();
-
+            this.currentMode = initialMode; //*furel - Mode group formation* 
             this.session = GroupChatGameComponent.Instance.GetOrCreateSession(participants);
+		
+		//*furel - Deleted Kickout list*
+        //    if (this.session.KickedOutColonists == null)
+        //        this.session.KickedOutColonists = new HashSet<Pawn>();
 
-            if (this.session.KickedOutColonists == null)
-                this.session.KickedOutColonists = new HashSet<Pawn>();
-
-            this.participants = participants
-                .Distinct()
-                .Where(p => !this.session.KickedOutColonists.Contains(p))
-                .ToList();
-
+            // this.participants = participants
+                // .Distinct()
+                // .Where(p => !this.session.KickedOutColonists.Contains(p))
+                // .ToList();
+				
+			this.participants = participants.Distinct().ToList();
+			
             if (this.participants.Count == 0 || !this.participants.Contains(this.initiator))
             {
                 this.participants.Clear();
                 this.participants.Add(this.initiator);
-                this.session.KickedOutColonists.Remove(this.initiator);
+                //this.session.KickedOutColonists.Remove(this.initiator); *furel - Deleted Kickout list*
             }
 
             this.session = GroupChatGameComponent.Instance
@@ -187,13 +201,11 @@ namespace EchoColony
             DrawPortraits(inRect, ref y); //y=45
         }
 
-        //*furel* Portraits go of windows if there are too mucho. Added a scroll. 
+
         private void DrawPortraits(Rect inRect, ref float y)
         {
             float size    = 60f;
             float spacing = 15f;
-            //float total   = participants.Count * (size + spacing);
-            //float startX  = (inRect.width - total) / 2f;
             float rowHeight = size + 25f;
 
             Rect scrollRect = new Rect(10f, y, inRect.width - 20f, rowHeight + 16f);
@@ -245,74 +257,106 @@ namespace EchoColony
             y += scrollRect.height + 10f;
         }
 
+		//*furel - Mode group formation* Changed how the management panel is drawn, `pliting the space in this call and creating two separated calls to draw their respective spaces 
         // ── Participant management panel ─────────────────────────────────────────
 
         private void DrawParticipantManagement(Rect inRect, ref float y)
-        {
-            Rect panelRect = new Rect(10f, y, inRect.width - 20f, 160f);
-            Widgets.DrawBoxSolid(panelRect, new Color(0.2f, 0.2f, 0.2f, 0.8f));
+        {  
+            float splitX = inRect.width * 0.15f;
+            Rect panelModes = new Rect(inRect.x + 5f, y, splitX - 10f, 160f);
+            Rect panelList = new Rect(inRect.x + splitX + 5f, y, inRect.width - splitX - 15f, 160f);
 
-            Widgets.Label(new Rect(panelRect.x + 10f, panelRect.y + 5f, 300f, 25f),
-                "EchoColony.GCWManagerColonNear".Translate(availableColonists.Count));
+            DrawModeSelectionMenu(panelModes); //*furel - Mode group formation* Call for Mode selesction menu.
 
-            if (KickedOut.Count > 0)
-            {
-                GUI.color = new Color(1f, 0.7f, 0.7f);
-                Widgets.Label(new Rect(panelRect.x + 320f, panelRect.y + 5f, 200f, 25f),
-                    "EchoColony.GCWManagerKickedOut".Translate(KickedOut.Count));
-                GUI.color = Color.white;
-            }
+            DrawAvailableColonistsList(panelList); //*furel - Mode group formation* Call for pawns in range menu.
 
-            Rect scrollRect = new Rect(
-                panelRect.x + 10f, panelRect.y + 30f,
-                panelRect.width - 20f, 120f);
-
-            float rowH      = 25f;
-            var   allToShow = new List<(Pawn pawn, bool isKicked)>();
-
-            foreach (var c in availableColonists) allToShow.Add((c, false));
-
-            var kickedNearby = KickedOut
-                .Where(p => p?.Map == participants.FirstOrDefault()?.Map && !p.Dead)
-                .Where(p => IsBasicEligibleFromCenter(p, CalculateConversationCenter(), p.Map))
-                .ToList();
-            foreach (var k in kickedNearby) allToShow.Add((k, true));
-
-            Rect viewRect = new Rect(0, 0, scrollRect.width - 16f, allToShow.Count * rowH);
-            Widgets.BeginScrollView(scrollRect, ref participantsScrollPos, viewRect);
-
-            for (int i = 0; i < allToShow.Count; i++)
-            {
-                var (colonist, isKicked) = allToShow[i];
-                Rect rowRect = new Rect(0, i * rowH, viewRect.width, rowH - 2f);
-
-                if (isKicked)         Widgets.DrawBoxSolid(rowRect, new Color(0.5f, 0.2f, 0.2f, 0.3f));
-                else if (i % 2 == 0) Widgets.DrawBoxSolid(rowRect, new Color(0.1f, 0.1f, 0.1f, 0.5f));
-
-                float nameOffset = isKicked ? 25f : 5f;
-                if (isKicked)
-                {
-                    GUI.color = Color.red;
-                    Widgets.Label(new Rect(rowRect.x + 5f, rowRect.y, 20f, rowRect.height), "✗");
-                }
-                GUI.color = isKicked ? new Color(1f, 0.8f, 0.8f) : Color.white;
-                Widgets.Label(new Rect(rowRect.x + nameOffset, rowRect.y, 130f, rowRect.height), colonist.LabelShort);
-                GUI.color = Color.white;
-
-                float dist = colonist.Position.DistanceTo(CalculateConversationCenter());
-                Widgets.Label(new Rect(rowRect.x + 160f, rowRect.y, 80f, rowRect.height), $"{dist:F1}m");
-
-                Rect actionBtn = new Rect(rowRect.x + rowRect.width - 80f, rowRect.y + 2f, 75f, 20f);
-                GUI.color = isKicked ? Color.yellow : Color.green;
-                if (Widgets.ButtonText(actionBtn, isKicked ? "Re-add" : "Add"))
-                    AddParticipant(colonist);
-                GUI.color = Color.white;
-            }
-
-            Widgets.EndScrollView();
-            y += panelRect.height + 10f;
+            y += panelList.height + 10f;
         }
 
+        //*furel - Mode group formation* Separated function to draw mode menu.
+		private void DrawModeSelectionMenu(Rect rect)
+        {
+            float btnHeight = 24f;
+            float spacing = 5f;
+
+
+            // Title
+            Widgets.Label(new Rect(rect.x, rect.y, rect.width, 20f), "EchoColony.GCWSelectMode".Translate());
+
+            var modes = new[] 
+            {
+                (GroupSelectionMode.Room, "EchoColony.GCWModeRoom"),
+                (GroupSelectionMode.Area, "EchoColony.GCWModeArea"),
+                (GroupSelectionMode.MapWide, "EchoColony.GCWModeMap")
+            };
+
+            float currentY = rect.y + 25f;
+            
+            foreach (var mode in modes)
+            {
+                Rect r = new Rect(rect.x, currentY, rect.width, btnHeight);
+                bool isSelected = (currentMode == mode.Item1);
+
+                // Widgets.RadioButtonLabeled draws the circle and the leabel 
+                 //returns true when is selected.
+                if (Widgets.RadioButtonLabeled(r, mode.Item2.Translate(), isSelected))
+                {
+                    if (!isSelected)
+                    {
+                        SoundDefOf.Tick_High.PlayOneShotOnCamera();
+                        currentMode = mode.Item1;
+
+                        // Update the list on mode selection 
+                        UpdateAvailableColonists();
+                    }
+                }
+
+                currentY += btnHeight + spacing;
+            }
+        }
+		//*furel - Mode group formation* Separated function to draw the avariable colonist, deleted Kickout 
+		private void DrawAvailableColonistsList(Rect rect)
+        {
+            Widgets.DrawBoxSolid(rect, new Color(0.2f, 0.2f, 0.2f, 0.8f));
+
+            Widgets.Label(new Rect(rect.x + 10f, rect.y + 5f, rect.xMax - 10f, 25f),
+                "EchoColony.GCWManagerColonNear".Translate(availableColonists.Count));
+				
+            Widgets.Label(new Rect(rect.x + 10f, rect.y + 5f, 200f, 25f),
+            "EchoColony.GCWManagerColonNear".Translate(availableColonists.Count));
+			
+            Rect scrollRect = new Rect(rect.x + 10f, rect.y + 30f, rect.width - 10f, 120f);
+            float rowH = 25f;
+            Rect viewRect = new Rect(0, 0, scrollRect.width - 16f, availableColonists.Count * rowH);																		   
+            Widgets.BeginScrollView(scrollRect, ref participantsScrollPos, viewRect);
+
+            for (int i = 0; i < availableColonists.Count; i++)
+            {
+                Pawn colonist = availableColonists[i];
+                Rect rowRect = new Rect(0, i * rowH, viewRect.width, rowH - 2f);
+
+                // Backgroud line
+                if (i % 2 == 0) Widgets.DrawBoxSolid(rowRect, new Color(0.1f, 0.1f, 0.1f, 0.5f));
+
+                // Icon and Name					  
+                Widgets.Label(new Rect(rowRect.x + 5f, rowRect.y, 130f, rowRect.height), colonist.LabelShort);
+                float dist = (colonist.Position - initiator.Position).LengthHorizontal;
+                GUI.color = Color.gray;
+                Widgets.Label(new Rect(rowRect.x + 150f, rowRect.y, 60f, rowRect.height), $"{dist:F1}m");
+                GUI.color = Color.white;
+
+                // ADD Button
+                Rect addBtn = new Rect(rowRect.x + rowRect.width - 85f, rowRect.y + 2f, 80f, 20f);
+                if (Widgets.ButtonText(addBtn, "EchoColony.GCWAdd".Translate()))
+                {
+                    AddParticipant(colonist);
+                    UpdateAvailableColonists();
+                    SoundDefOf.Tick_High.PlayOneShotOnCamera();
+                }						
+            }
+            Widgets.EndScrollView();
+        }
+		
         // ── Chat area ────────────────────────────────────────────────────────────
 
         private void DrawChatArea(Rect inRect, ref float y)
@@ -320,6 +364,29 @@ namespace EchoColony
             float chatHeight = inRect.height - y - 80f;
             Rect  scrollRect = new Rect(10f, y, inRect.width - 20f, chatHeight);
             float viewW      = scrollRect.width - 16f;
+//------------------------------------------------------------------------------------
+            //*furel - text display* Shield the way text is displayed. If group chat window was closed and re-opened hight wasn't calculated propedly.
+			if (viewW < 50f) return;						
+
+            string currentLastMsg = session.History.Count > 0 ? session.History.Last() : null;
+
+            if (currentLastMsg != lastMessageTextSeen || lastMessageTextSeen != currentLastMsg)
+            {
+                cachedHeights.Clear();
+
+                Text.Font = GameFont.Small; 
+                foreach (string m in session.History)
+                {
+                    cachedHeights.Add(CalculateMessageHeight(m, viewW));
+                }
+                lastMessageTextSeen = currentLastMsg;
+            }
+
+            if (cachedHeights.Count > session.History.Count)
+            {
+                cachedHeights.RemoveRange(session.History.Count, cachedHeights.Count - session.History.Count);
+            }
+//-------------------------------------------------------------------------------------																					  
 
             while (cachedHeights.Count < session.History.Count) 												
             {
@@ -462,126 +529,118 @@ namespace EchoColony
         }
 
         // ── Participant management ────────────────────────────────────────────────
-
-        private void AddParticipant(Pawn pawn)
+		//*furel* Removed Kickout search
+        private void AddParticipant(Pawn p)
         {
-            if (participants.Contains(pawn)) return;
-
-            KickedOut.Remove(pawn);
-            participants.Add(pawn);
-            EnsureColorFor(pawn);
-
-            session = GroupChatGameComponent.Instance
-                .UpdateSessionParticipants(session, participants);
-
-            session.AddSystemMessage($"{pawn.LabelShort} joins the conversation");
-            UpdateAvailableColonists();
-            scrollPos.y = float.MaxValue;
+            if (p == null || participants.Contains(p)) return;
+								   
+            participants.Add(p);										 
+            session = GroupChatGameComponent.Instance.UpdateSessionParticipants(session, participants);								 
         }
 
-        private void RemoveParticipant(Pawn pawn)
+        private void RemoveParticipant(Pawn p)
         {
-            if (participants.Count < 3 || pawn == initiator) return;
+            if (p == initiator) return;
 
-            participants.Remove(pawn);
-            KickedOut.Add(pawn);
-
-            session = GroupChatGameComponent.Instance
-                .UpdateSessionParticipants(session, participants);
-
-            this.cachedHeights.Clear();																							 
-
-            session.AddSystemMessage($"{pawn.LabelShort} stepped away");
-            UpdateAvailableColonists();
-            scrollPos.y = float.MaxValue;
+            if (participants.Contains(p))
+            {
+                participants.Remove(p);
+                // Actualizamos la sesión
+                session = GroupChatGameComponent.Instance.UpdateSessionParticipants(session, participants);
+                UpdateAvailableColonists();
+            }						 
         }
-
         // ── Proximity helpers ────────────────────────────────────────────────────
 
         private void UpdateAvailableColonists()
         {
-            if (participants == null || participants.Count == 0)
-            { availableColonists.Clear(); return; }
+			if (initiator == null || initiator.Map == null) return;
+			List<Pawn> potentialCandidates;
 
-            IntVec3 center = CalculateConversationCenter();
-            Map     map    = participants[0].Map;
-            if (map == null || !center.IsValid) { availableColonists.Clear(); return; }
-
-            CleanupKickedOutList();
-
-            availableColonists = GetChatEligibleColonistsFromCenter(center, map, participants)
-                .Where(p => !KickedOut.Contains(p))
-                .ToList();
-        }
-
-        private IntVec3 CalculateConversationCenter()
-        {
-            if (participants.Count == 0) return IntVec3.Invalid;
-            if (participants.Count == 1) return participants[0].Position;
-            return CellRect.FromLimits(
-                participants.Min(p => p.Position.x), participants.Min(p => p.Position.z),
-                participants.Max(p => p.Position.x), participants.Max(p => p.Position.z)
-            ).CenterCell;
-        }
-
-        private void CleanupKickedOutList()
-        {
-            if (KickedOut == null) return;
-            var dead = KickedOut
-                .Where(p => p.Dead || p.Map == null ||
-                            p.Map != participants.FirstOrDefault()?.Map)
-                .ToList();
-            foreach (var p in dead) KickedOut.Remove(p);
-        }
-
-        private List<Pawn> GetChatEligibleColonistsFromCenter(
-            IntVec3 center, Map map, List<Pawn> exclude)
-        {
-            exclude = exclude ?? new List<Pawn>();
-            return map.mapPawns.FreeColonistsSpawned
-                .Where(p => !exclude.Contains(p) &&
-                            IsBasicEligibleFromCenter(p, center, map) &&
-                            CanCommunicateFromCenter(center, map, p))
-                .ToList();
-        }
-
-        private bool IsBasicEligibleFromCenter(Pawn p, IntVec3 center, Map map)
-        {
-            if (p == null || map == null || p.Dead || p.Map != map) return false;
-            if (!p.RaceProps.Humanlike || p.Faction != Faction.OfPlayer) return false;
-            return p.Position.DistanceTo(center) <= MAX_CHAT_DISTANCE;
-        }
-
-        private bool CanCommunicateFromCenter(IntVec3 center, Map map, Pawn colonist)
-        {
-            if (map == null || colonist?.Map != map) return false;
-
-            Room centerRoom   = center.GetRoom(map);
-            Room colonistRoom = colonist.Position.GetRoom(map);
-
-            if (centerRoom != null && colonistRoom != null && centerRoom == colonistRoom)
-                return true;
-
-            float dist = center.DistanceTo(colonist.Position);
-            if (dist > OUTDOOR_CHAT_DISTANCE) return false;
-
-            if (centerRoom == null && colonistRoom == null)
-                return GenSight.LineOfSight(center, colonist.Position, map, true);
-
-            return HasDirectConnection(center, colonist.Position, map);
-        }
-
-        private bool HasDirectConnection(IntVec3 from, IntVec3 to, Map map)
-        {
-            if (!GenSight.LineOfSight(from, to, map, true)) return false;
-            foreach (var cell in GenSight.PointsOnLineOfSight(from, to))
+            // *furel* Seleccionamos la lógica de búsqueda según el modo activo
+            switch (currentMode)
             {
-                if (!cell.InBounds(map)) continue;
-                if (cell.GetDoor(map) is Building_Door door) return door.Open;
-                if (cell.Filled(map)) return false;
+                case GroupSelectionMode.Room:
+                    // Busca peones en la misma habitación que el iniciador[cite: 1]
+                    potentialCandidates = GetPawnsInRoom(initiator);
+                    break;
+
+                case GroupSelectionMode.Area:
+                    // Busca peones en un radio de 15 celdas (puedes usar la constante MAX_CHAT_DISTANCE)[cite: 1]
+                    potentialCandidates = GetPawnsInArea(initiator, 15f);
+                    break;
+
+                case GroupSelectionMode.MapWide:
+                default:
+                    // Busca a todos los colonos y esclavos válidos en todo el mapa[cite: 1]
+                    potentialCandidates = GetAllValidPawnsOnMap(initiator);
+                    break;
             }
-            return true;
+
+            availableColonists = potentialCandidates
+                .Where(p => !participants.Contains(p))
+                .ToList();
         }
+
+       // private IntVec3 CalculateConversationCenter()
+        // {
+            // if (participants.Count == 0) return IntVec3.Invalid;
+            // if (participants.Count == 1) return participants[0].Position;
+            // return CellRect.FromLimits(
+                // participants.Min(p => p.Position.x), participants.Min(p => p.Position.z),
+                // participants.Max(p => p.Position.x), participants.Max(p => p.Position.z)
+            // ).CenterCell;
+        // }
+
+
+        // private List<Pawn> GetChatEligibleColonistsFromCenter(
+            // IntVec3 center, Map map, List<Pawn> exclude)
+        // {
+            // exclude = exclude ?? new List<Pawn>();
+            // return map.mapPawns.FreeColonistsSpawned
+                // .Where(p => !exclude.Contains(p) &&
+                            // IsBasicEligibleFromCenter(p, center, map) &&
+                            // CanCommunicateFromCenter(center, map, p))
+                // .ToList();
+        // }
+
+        // private bool IsBasicEligibleFromCenter(Pawn p, IntVec3 center, Map map)
+        // {
+            // if (p == null || map == null || p.Dead || p.Map != map) return false;
+            // if (!p.RaceProps.Humanlike || p.Faction != Faction.OfPlayer) return false;
+            // return p.Position.DistanceTo(center) <= MAX_CHAT_DISTANCE;
+        // }
+
+        // private bool CanCommunicateFromCenter(IntVec3 center, Map map, Pawn colonist)
+        // {
+            // if (map == null || colonist?.Map != map) return false;
+
+            // Room centerRoom   = center.GetRoom(map);
+            // Room colonistRoom = colonist.Position.GetRoom(map);
+
+            // if (centerRoom != null && colonistRoom != null && centerRoom == colonistRoom)
+                // return true;
+
+            // float dist = center.DistanceTo(colonist.Position);
+            // if (dist > OUTDOOR_CHAT_DISTANCE) return false;
+
+            // if (centerRoom == null && colonistRoom == null)
+                // return GenSight.LineOfSight(center, colonist.Position, map, true);
+
+            // return HasDirectConnection(center, colonist.Position, map);
+        // }
+
+        // private bool HasDirectConnection(IntVec3 from, IntVec3 to, Map map)
+        // {
+            // if (!GenSight.LineOfSight(from, to, map, true)) return false;
+            // foreach (var cell in GenSight.PointsOnLineOfSight(from, to))
+            // {
+                // if (!cell.InBounds(map)) continue;
+                // if (cell.GetDoor(map) is Building_Door door) return door.Open;
+                // if (cell.Filled(map)) return false;
+            // }
+            // return true;
+        // }
 
         // ── Conversation coroutine ────────────────────────────────────────────────
 
@@ -607,22 +666,24 @@ namespace EchoColony
         private IEnumerator GroupChatCoroutine(List<Pawn> group, string message)
         {
             Map     map    = group[0].Map;
-            IntVec3 center = CalculateCenter(group);
+			
+			//*furel* Pawns are asigned on opening the windos. No needed with the new system.
+            // IntVec3 center = CalculateCenter(group);
 
-            for (int i = group.Count - 1; i >= 0; i--)
-            {
-                var p = group[i];
-                if (p.Dead || p.Map != map)
-                {
-                    session.AddSystemMessage($"{p.LabelShort} is no longer present");
-                    group.RemoveAt(i);
-                }
-                else if (!CanCommunicateFromCenter(center, map, p))
-                {
-                    session.AddSystemMessage($"{p.LabelShort} moved too far away");
-                    group.RemoveAt(i);
-                }
-            }
+            //for (int i = group.Count - 1; i >= 0; i--)
+            //{
+            //    var p = group[i];
+            //    if (p.Dead || p.Map != map)
+            //    {
+            //        session.AddSystemMessage($"{p.LabelShort} is no longer present");
+            //        group.RemoveAt(i);
+            //    }
+            //    else if (!CanCommunicateFromCenter(center, map, p))
+            //   {
+            //        session.AddSystemMessage($"{p.LabelShort} moved too far away");
+            //        group.RemoveAt(i);
+            //    }
+            //}
 
             if (group.Count == 0)
             {
@@ -630,7 +691,7 @@ namespace EchoColony
                 yield break;
             }
 
-            center = CalculateCenter(group);
+            //center = CalculateCenter(group); *furel* no needed with the new system.
 
             var participationCount = new Dictionary<Pawn, int>();
             foreach (var p in group) participationCount[p] = 0;
@@ -753,15 +814,15 @@ namespace EchoColony
             return trimmed;
         }
 
-        private IntVec3 CalculateCenter(List<Pawn> group)
-        {
-            if (group.Count == 0) return IntVec3.Invalid;
-            if (group.Count == 1) return group[0].Position;
-            return CellRect.FromLimits(
-                group.Min(p => p.Position.x), group.Min(p => p.Position.z),
-                group.Max(p => p.Position.x), group.Max(p => p.Position.z)
-            ).CenterCell;
-        }
+        // private IntVec3 CalculateCenter(List<Pawn> group)
+        // {
+            // if (group.Count == 0) return IntVec3.Invalid;
+            // if (group.Count == 1) return group[0].Position;
+            // return CellRect.FromLimits(
+                // group.Min(p => p.Position.x), group.Min(p => p.Position.z),
+                // group.Max(p => p.Position.x), group.Max(p => p.Position.z)
+            // ).CenterCell;
+        // }
 
         // ── Speaker selection ────────────────────────────────────────────────────
 
@@ -969,14 +1030,16 @@ namespace EchoColony
         }
 
         // ── Height Text Calculation ────────────────────────────────────────────────────────
-
+		//*furel* Sometimes the text gets cut off, so I give it a little more space and trim the space used to calculate the height to force it to increase.
         private float CalculateMessageHeight(string msg, float width)
         {
+			Text.Font = GameFont.Small;						   
             if (GroupChatSession.IsSystemMessage(msg)) return 24f;
 
+			float safeWidth = width - 8f;							 
             string displayText = GroupChatSession.GetDisplayText(msg);
             if (msg.StartsWith("You:") || msg.StartsWith("You::"))
-                return Text.CalcHeight(displayText, width) + 4f;
+                return Text.CalcHeight(displayText, safeWidth) + 6f;
 
             int colonIdx = displayText.IndexOf(": ");
             if (colonIdx > 0)
@@ -984,11 +1047,11 @@ namespace EchoColony
                 string nameWithColon = displayText.Substring(0, colonIdx) + ": ";
                 float nameW = Text.CalcSize(nameWithColon).x;
                 string body = displayText.Substring(colonIdx + 2);
-                float bodyH = Text.CalcHeight(body, width - nameW) + 4f;
-                float fullH = Text.CalcHeight(displayText, width) + 4f;
+                float bodyH = Text.CalcHeight(body, safeWidth - nameW) + 6f;
+                float fullH = Text.CalcHeight(displayText, safeWidth) + 6f;
                 return Mathf.Max(fullH, bodyH);
             }
-            return Text.CalcHeight(displayText, width) + 4f;
+            return Text.CalcHeight(displayText, safeWidth) + 6f;
         }
 		
         private void ClearChat()
@@ -1002,6 +1065,97 @@ namespace EchoColony
                     session.AddSystemMessage("EchoColony.GCWClearConfirmation".Translate());
                     Messages.Message("EchoColony.GCWClearConfirmation".Translate(), MessageTypeDefOf.NeutralEvent);
                 }));
+        }
+
+        //*furel* Get the list of pawns on a room.
+        // ── Get Pawn Room List ────────────────────────────────────────────────────────
+        public static List<Pawn> GetPawnsInRoom(Pawn initiator)
+        {
+            List<Pawn> results = new List<Pawn>();
+            if (initiator?.Map == null) return results;
+
+            // Check which rooms the initiator pawn is in, or if it's outside. If it's right in a doorway, take both rooms.
+            var initiatorRooms = GetAllRoomsForPawn(initiator, out bool initiatorTouchesExterior);
+
+            float exteriorRadius = 15f;
+            foreach (Pawn p in initiator.Map.mapPawns.AllPawnsSpawned)
+            {
+                if (p == initiator || !Patch_ChatGizmo.IsValidForGroupChat(p)) continue;
+
+                //Check which rooms the pawn is in, or if it's outside. If it's right in a doorway, take both rooms.
+                var pRooms = GetAllRoomsForPawn(p, out bool pTouchesExterior);
+
+				//If the starter and the pawn share space, add the pawn to the list.
+                if (initiatorRooms.Overlaps(pRooms) || (initiatorTouchesExterior && pTouchesExterior && p.Position.InHorDistOf(initiator.Position, exteriorRadius)))
+                {
+                    results.Add(p);
+                }
+            }
+            return results;
+        }
+
+        //*furel* Get the list of pawns on an area. 15f is the default Radious
+        // ── Get Pawn Area List (15 radious)────────────────────────────────────────────────────────
+        public static List<Pawn> GetPawnsInArea(Pawn initiator, float radius)
+        {
+            List<Pawn> inArea = new List<Pawn>();
+
+            Map map = initiator.Map;
+            if (map == null) return inArea;
+
+            foreach (Pawn p in map.mapPawns.AllPawnsSpawned)
+            {
+                if (p != initiator && Patch_ChatGizmo.IsValidForGroupChat(p))
+                {
+                    if (p.Position.InHorDistOf(initiator.Position, radius))
+                    {
+                        inArea.Add(p);
+                    }
+                }
+            }
+            return inArea;
+        }
+
+        //*furel* Get the list of pawns on a map.
+        // ── Get Pawn Map List ────────────────────────────────────────────────────────
+        private List<Pawn> GetAllValidPawnsOnMap(Pawn initiator)
+        {
+            return initiator.Map.mapPawns.AllPawnsSpawned
+                .Where(p => p != initiator && Patch_ChatGizmo.IsValidForGroupChat(p))
+                .ToList();
+        }
+
+        //*furel* A filter for pawns between rooms or exteriors. If the pawn is right at the door separating an interior from an exterior, it takes the room it is entering or leaving.
+        //─── Door check position ────────────────────────────────────────────────────────
+        private static HashSet<Room> GetAllRoomsForPawn(Pawn p, out bool touchesExterior)
+        {
+            HashSet<Room> rooms = new HashSet<Room>();
+            touchesExterior = false;
+
+            if (p?.Map == null) return rooms;
+
+            foreach (IntVec3 cell in GenAdj.AdjacentCellsAndInside)
+            {
+                IntVec3 checkPos = p.Position + cell;
+                if (checkPos.InBounds(p.Map))
+                {
+                    Room room = checkPos.GetRoom(p.Map);
+                    if (room != null)
+                    {
+                        if (room.PsychologicallyOutdoors) touchesExterior = true;
+                        else rooms.Add(room);
+                    }
+                }
+            }
+            return rooms;
+        }
+		
+		//*Furel* Cleans variables to be sure.
+        public override void PostOpen()
+        {
+            base.PostOpen();
+            cachedHeights.Clear();
+            lastMessageTextSeen = null;
         }
     }
 }

--- a/source/group/ColonistGroupChatWindow.cs
+++ b/source/group/ColonistGroupChatWindow.cs
@@ -323,7 +323,7 @@ namespace EchoColony
                 "EchoColony.GCWManagerColonNear".Translate(availableColonists.Count));
 				
             Widgets.Label(new Rect(rect.x + 10f, rect.y + 5f, 200f, 25f),
-            "EchoColony.GCWManagerColonNear".Translate(availableColonists.Count));
+                "EchoColony.GCWManagerColonNear".Translate(availableColonists.Count));
 			
             Rect scrollRect = new Rect(rect.x + 10f, rect.y + 30f, rect.width - 10f, 120f);
             float rowH = 25f;
@@ -514,7 +514,7 @@ namespace EchoColony
             });
 
             Rect sendRect = new Rect(inputRect.xMax + gap, y, btnW, 60f);
-            bool clicked  = Widgets.ButtonText(sendRect, "Send");
+            bool clicked  = Widgets.ButtonText(sendRect, "EchoColony.GCWSend".Translate());
 
             if ((clicked || sendRequestedViaEnter) && !userMessage.NullOrEmpty())
             {

--- a/source/group/GroupChatGameComponent.cs
+++ b/source/group/GroupChatGameComponent.cs
@@ -21,17 +21,15 @@ namespace EchoColony
         // Returns an existing session whose participant set matches EXACTLY,
         // or creates a new one. Subset matching is intentionally avoided —
         // it was causing sessions with extra participants to be reused.
-        //*furel - improved id creation and search* Search for a existing id whit listed pawns or crates one if there is not exist 
         public GroupChatSession GetOrCreateSession(List<Pawn> participants)
         {
-            var existing = GetSession(participants);  //*furel - improved id creation and search* Uses GetSession to search for a existing session for given pawns. Returns null if none is foud.
+            var existing = GetSession(participants);
             if (existing != null) return existing;
 
-            //*fuel - improved id creation and search* Crates the id for the session but is not register until a messege from the user is sended to the IA.
+            //Crates the id for the session but is not register until a messege from the user is sended to the IA.
             return new GroupChatSession(Guid.NewGuid().ToString(), participants);
         }
 
-        //*furel - improved id creation and search* Modified GetSession to actualy just get the session that matches the probided list and be usen in GetOrCreateSession and UpdateSessionParticipants. Returns null isf none is found.
         private GroupChatSession GetSession(List<Pawn> participants)
         {
             var requestedIds = participants
@@ -44,21 +42,18 @@ namespace EchoColony
                 s.ParticipantIds.OrderBy(id => id).SequenceEqual(requestedIds));
         }
 
-        // Updates the participant list of an existing session.
+        // Searches for an existing session ID that matches the current participants; 
+		// if it doesn't find one, it creates a new one.
         // Called when a participant is added or removed mid-conversation.
-        //*furel - improved id creation and search* The original code creates many session IDs. Every time a window opens and participants change, an ID is created, but existing IDs are never searched.
-        //                                      This method searches for an existing session ID that matches the current participants; if it doesn't find one, it creates a new one.
-        //                                      It doesn't record it until a message is sent to the AI.
         public GroupChatSession UpdateSessionParticipants(GroupChatSession existing, List<Pawn> newParticipants)
         {
             var match = GetSession(newParticipants);
             if (match != null) return match;
-
-            //*fuel - improved id creation and search* Crates the id for the session but is not register yet.
+			
             return new GroupChatSession(Guid.NewGuid().ToString(), newParticipants);
         }
 
-        //*furel - hold registration* Here is were we registrer the session in the save file.
+        //Registrer the session in the save file.
         public void RegistingSession(GroupChatSession session)
         {
             if (!groupChats.ContainsKey(session.SessionId))

--- a/source/group/GroupChatSession.cs
+++ b/source/group/GroupChatSession.cs
@@ -20,7 +20,7 @@ namespace EchoColony
         // so they can be rendered differently in the UI
         public const string SystemPrefix = "[SYSTEM]";
 
-        public HashSet<Pawn> KickedOutColonists = new HashSet<Pawn>();
+        //public HashSet<Pawn> KickedOutColonists = new HashSet<Pawn>(); *furel* removed KickOut
 
         public GroupChatSession() { }
 
@@ -116,13 +116,13 @@ namespace EchoColony
             Scribe_Collections.Look(ref ParticipantIds, "ParticipantIds", LookMode.Value);
             Scribe_Collections.Look(ref History,        "History",        LookMode.Value);
             Scribe_Values.Look(ref lastSessionDay,      "lastSessionDay", -1);
-            Scribe_Collections.Look(ref KickedOutColonists, "KickedOutColonists", LookMode.Reference);
+            //Scribe_Collections.Look(ref KickedOutColonists, "KickedOutColonists", LookMode.Reference);
 
             if (Scribe.mode == LoadSaveMode.PostLoadInit)
             {
                 if (ParticipantIds   == null) ParticipantIds   = new List<string>();
                 if (History          == null) History          = new List<string>();
-                if (KickedOutColonists == null) KickedOutColonists = new HashSet<Pawn>();
+                //if (KickedOutColonists == null) KickedOutColonists = new HashSet<Pawn>();
 
                 LastInteractionTime = Time.realtimeSinceStartup;
             }


### PR DESCRIPTION
The group formation behavior has been modified.

A selection menu has been added to choose between:
- Room (or nearby): Selects pawns in a room or those within a 15-tile radius of the initiator if they are outside. Pawns in a different room are not included.
- Area: Selects any pawn within a 15-tile area, even through walls.
- Map: Allows you to add any valid pawn on the map, regardless of distance.

Each mode allows you to manually add pawns to the group according to these rules; it does not modify the active group chat, even if the active pawns do not follow the selected rule. For example: Pawns A and B are in the same room, while pawn C is on the other side of the map. If you select all three, open the group chat window, and change the mode to Room, these three pawns will remain active members. However, when pawn C is removed, it will not appear for selection in the management screen unless you return to Map mode.

Group chat window opening:
If a pawn is selected, the group chat window opens in Room mode.

If multiple pawns are selected, the group chat window opens in Map mode.

The KickedOut list and checks have been removed. 
I found no reason to keep them; they only complicated the code and consumed unnecessary calculations, so I removed them.