### PR TITLE
Fix bionic part detection and add trait descriptions to prompts

### DIFF
--- a/source/ColonistPromptContextBuilder.cs
+++ b/source/ColonistPromptContextBuilder.cs
@@ -520,7 +520,16 @@ namespace EchoColony
             foreach (var disease in diseases)
                 healthStatus.Add($"sick with {disease.def.label}");
 
-            var missingParts = hediffs.OfType<Hediff_MissingPart>().ToList();
+            // Build set of body parts covered by a prosthetic or bionic
+            var prostheticParts = new HashSet<BodyPartRecord>(
+                hediffs.Where(h => h.def.addedPartProps != null && h.Part != null)
+                    .Select(h => h.Part));
+
+            // Only list missing parts NOT covered by a prosthetic above them in the hierarchy
+            var missingParts = hediffs.OfType<Hediff_MissingPart>()
+                .Where(h => h.Part != null && !IsPartCoveredByProsthetic(h.Part, prostheticParts))
+                .ToList();
+
             if (missingParts.Any())
             {
                 var parts = missingParts.Select(h => h.Part.Label).Distinct();
@@ -602,6 +611,20 @@ namespace EchoColony
                 : "";
         }
 
+        /// <summary>
+        /// Returns true if the given body part or any of its ancestors has a prosthetic or bionic installed,
+        /// meaning missing part hediffs below it should not be listed as truly missing.
+        /// </summary>
+        private static bool IsPartCoveredByProsthetic(BodyPartRecord part, HashSet<BodyPartRecord> prostheticParts)
+        {
+            var current = part;
+            while (current != null)
+            {
+                if (prostheticParts.Contains(current)) return true;
+                current = current.parent;
+            }
+            return false;
+        }
         private static string BuildOptimizedThoughts(Pawn pawn)
         {
             var memories = pawn.needs?.mood?.thoughts?.memories?.Memories;
@@ -1261,12 +1284,28 @@ namespace EchoColony
         }
 
         private static string BuildTraits(Pawn pawn)
-        {
-            if (pawn.story?.traits == null || !pawn.story.traits.allTraits.Any())
-                return "*Traits:* None";
+{
+    if (pawn.story?.traits == null || !pawn.story.traits.allTraits.Any())
+        return "*Traits:* None";
 
-            return "*Traits:* " + string.Join(", ", pawn.story.traits.allTraits.Select(t => t.LabelCap));
-        }
+    var entries = pawn.story.traits.allTraits.Select(t =>
+    {
+            string desc = t.def.description;
+            if (!string.IsNullOrEmpty(desc))
+            {
+                desc = System.Text.RegularExpressions.Regex.Replace(desc, "<.*?>", "");
+                desc = desc.Replace("[PAWN_nameDef]", pawn.LabelShort)
+                        .Replace("[PAWN_pronoun]", pawn.gender == Gender.Male ? "he" : "she")
+                        .Replace("[PAWN_possessive]", pawn.gender == Gender.Male ? "his" : "her")
+                        .Trim();
+                if (desc.Length > 120) desc = desc.Substring(0, 117) + "...";
+                return $"{t.LabelCap}: {desc}";
+            }
+            return t.LabelCap;
+        });
+
+        return "*Traits:* " + string.Join("\n  - ", entries);
+    }
 
         private static string BuildHealthInfo(Pawn pawn)
         {

--- a/source/Conversations/PawnConversationPromptBuilder.cs
+++ b/source/Conversations/PawnConversationPromptBuilder.cs
@@ -281,7 +281,20 @@ namespace EchoColony.Conversations
                 sb.AppendLine($"Background: {backstory}");
 
             if (pawn.story?.traits?.allTraits != null && pawn.story.traits.allTraits.Any())
-                sb.AppendLine($"Personality: {string.Join(", ", pawn.story.traits.allTraits.Select(t => t.LabelCap))}");
+            {
+                var traitEntries = pawn.story.traits.allTraits.Select(t =>
+                {
+                    string desc = t.def.description;
+                    if (!string.IsNullOrEmpty(desc))
+                    {
+                        desc = System.Text.RegularExpressions.Regex.Replace(desc, "<.*?>", "").Trim();
+                        if (desc.Length > 100) desc = desc.Substring(0, 97) + "...";
+                        return $"{t.LabelCap}: {desc}";
+                    }
+                    return t.LabelCap;
+                });
+                sb.AppendLine($"Personality:\n  - {string.Join("\n  - ", traitEntries)}");
+            }
 
             string traitSpeech = GetTraitSpeechStyle(pawn);
             if (!string.IsNullOrEmpty(traitSpeech))
@@ -540,8 +553,14 @@ namespace EchoColony.Conversations
             if (spinalInjury != null)
                 return $"[MOBILITY: SPINAL INJURY ({spinalInjury.def.label}) — movement severely impaired due to structural damage to the spine, not pain alone]";
 
+            var prostheticParts = new HashSet<BodyPartRecord>(
+                hediffSet.hediffs
+                    .Where(h => h.def?.addedPartProps != null && h.Part != null)
+                    .Select(h => h.Part));
+
             var missingLegs = hediffSet.hediffs.OfType<Hediff_MissingPart>()
-                .Where(h => h.Part?.def?.defName == "Leg" || h.Part?.def?.defName == "Foot")
+                .Where(h => (h.Part?.def?.defName == "Leg" || h.Part?.def?.defName == "Foot")
+                        && !IsPartCoveredByProsthetic(h.Part, prostheticParts))
                 .ToList();
             if (missingLegs.Count >= 2)
                 return "[MOBILITY: Both legs missing — cannot walk at all without prosthetics]";
@@ -651,6 +670,17 @@ namespace EchoColony.Conversations
             return $"[CHEMICAL STATE: {string.Join("; ", states)}]";
         }
 
+        private static bool IsPartCoveredByProsthetic(BodyPartRecord part, HashSet<BodyPartRecord> prostheticParts)
+        {
+            var current = part;
+            while (current != null)
+            {
+                if (prostheticParts.Contains(current)) return true;
+                current = current.parent;
+            }
+            return false;
+        }
+
         // ── Speech impediment detection ───────────────────────────────────────────
 
         private static string GetSpeechImpediment(Pawn pawn)
@@ -698,34 +728,41 @@ namespace EchoColony.Conversations
         // ── Significant health conditions ─────────────────────────────────────────
 
         private static List<string> GetSignificantHealthConditions(Pawn pawn)
+{
+    var result = new List<string>();
+    var hediffSet = pawn.health?.hediffSet;
+    if (hediffSet == null) return result;
+
+    // Build set of parts covered by a prosthetic or bionic
+    var prostheticParts = new HashSet<BodyPartRecord>(
+        hediffSet.hediffs
+            .Where(h => h.def?.addedPartProps != null && h.Part != null)
+            .Select(h => h.Part));
+
+    foreach (var h in hediffSet.hediffs)
+    {
+        if (h?.def == null) continue;
+        if (h.def.defName == "MissingBodyPart")
         {
-            var result = new List<string>();
-            var hediffSet = pawn.health?.hediffSet;
-            if (hediffSet == null) return result;
-
-            foreach (var h in hediffSet.hediffs)
-            {
-                if (h?.def == null) continue;
-                if (h.def.defName == "MissingBodyPart")
-                {
-                    string partName = h.Part?.def?.label ?? "body part";
-                    if (h.Part?.def?.defName == "Tongue" || h.Part?.def?.defName == "Jaw") continue;
-                    result.Add($"missing {partName}");
-                }
-            }
-
-            var badHediffs = hediffSet.hediffs
-                .Where(h => h.Visible && h.def.isBad &&
-                            h.def.defName != "MissingBodyPart" &&
-                            h.Severity > 0.25f)
-                .OrderByDescending(h => h.Severity)
-                .Take(3)
-                .Select(h => h.def.label)
-                .ToList();
-
-            result.AddRange(badHediffs);
-            return result;
+            if (h.Part == null) continue;
+            if (h.Part.def?.defName == "Tongue" || h.Part.def?.defName == "Jaw") continue;
+            if (IsPartCoveredByProsthetic(h.Part, prostheticParts)) continue;
+            result.Add($"missing {h.Part.def?.label ?? "body part"}");
         }
+    }
+
+    var badHediffs = hediffSet.hediffs
+        .Where(h => h.Visible && h.def.isBad &&
+                    h.def.defName != "MissingBodyPart" &&
+                    h.Severity > 0.25f)
+        .OrderByDescending(h => h.Severity)
+        .Take(3)
+        .Select(h => h.def.label)
+        .ToList();
+
+    result.AddRange(badHediffs);
+    return result;
+}
 
         // ── Pain descriptor ───────────────────────────────────────────────────────
 

--- a/source/Conversations/PawnMonologuePromptBuilder.cs
+++ b/source/Conversations/PawnMonologuePromptBuilder.cs
@@ -75,8 +75,18 @@ namespace EchoColony.Conversations
             var traits = pawn.story?.traits?.allTraits;
             if (traits != null && traits.Count > 0)
             {
-                var traitLabels = traits.Take(3).Select(t => t.LabelCap).ToList();
-                sb.AppendLine($"Traits: {string.Join(", ", traitLabels)}");
+                var traitEntries = traits.Take(3).Select(t =>
+                {
+                    string desc = t.def.description;
+                    if (!string.IsNullOrEmpty(desc))
+                    {
+                        desc = System.Text.RegularExpressions.Regex.Replace(desc, "<.*?>", "").Trim();
+                        if (desc.Length > 80) desc = desc.Substring(0, 77) + "...";
+                        return $"{t.LabelCap}: {desc}";
+                    }
+                    return t.LabelCap;
+                });
+                sb.AppendLine($"Traits: {string.Join(" / ", traitEntries)}");
             }
 
             // Top skill

--- a/source/GeminiAPI.cs
+++ b/source/GeminiAPI.cs
@@ -762,7 +762,8 @@ namespace EchoColony
                     break;
                 case LocalModelProvider.Ollama:
                 default:
-                    jsonBody = $"{{\"model\": \"{modelName}\", \"prompt\": \"{EscapeJson(prompt)}\", \"stream\": false, \"options\": {{\"num_ctx\": 16384}}}}";
+                    string thinkFlag = MyMod.Settings?.ollamaDisableThinking == true ? ", \"think\": false" : "";
+                    jsonBody = $"{{\"model\": \"{modelName}\", \"prompt\": \"{EscapeJson(prompt)}\", \"stream\": false{thinkFlag}, \"options\": {{\"num_ctx\": 16384}}}}";
                     break;
             }
 

--- a/source/GeminiSettings.cs
+++ b/source/GeminiSettings.cs
@@ -189,6 +189,8 @@ namespace EchoColony
         // EXPOSE DATA
         // ═══════════════════════════════════════════════════════════════
 
+        public bool ollamaDisableThinking = false;
+
         public override void ExposeData()
         {
             base.ExposeData();
@@ -208,7 +210,8 @@ namespace EchoColony
 
             Scribe_Values.Look(ref localModelEndpoint, "LocalModelEndpoint", "http://localhost:11434/api/generate");
             Scribe_Values.Look(ref localModelName,     "LocalModelName",     "llama3.2:latest");
-            Scribe_Values.Look(ref localModelProvider, "localModelProvider", LocalModelProvider.LMStudio);
+            Scribe_Values.Look(ref localModelProvider,  "localModelProvider", LocalModelProvider.LMStudio);
+            Scribe_Values.Look(ref ollamaDisableThinking,  "ollamaDisableThinking",  false);
 
             Scribe_Values.Look(ref openRouterEndpoint, "OpenRouterEndpoint", "https://openrouter.ai/api/v1/chat/completions");
             Scribe_Values.Look(ref openRouterApiKey,   "OpenRouterApiKey",   "");

--- a/source/MyMod.cs
+++ b/source/MyMod.cs
@@ -486,6 +486,15 @@ namespace EchoColony
             Settings.localModelEndpoint = list.TextEntry(Settings.localModelEndpoint);
             list.Label("EchoColony.LocalModelName".Translate());
             Settings.localModelName = list.TextEntry(Settings.localModelName);
+
+            if (Settings.localModelProvider == LocalModelProvider.Ollama)
+            {
+                list.Gap(4f);
+                list.CheckboxLabeled(
+                    "Disable thinking mode (Qwen3 and similar models)",
+                    ref Settings.ollamaDisableThinking,
+                    "Adds 'think: false' to Ollama requests. Faster responses but may reduce reasoning quality.");
+            }
         }
 
         private void DrawOpenRouterSettings(Listing_Standard list)


### PR DESCRIPTION
## What changed

### Fix: Bionic and prosthetic parts no longer listed as missing

RimWorld internally keeps `MissingBodyPart` records even when a bionic or prosthetic covers them. The prompt builders were reading all missing part entries without checking whether they were covered by an implant above them in the body hierarchy — causing the AI to receive contradictory information like "missing shoulder, humerus, radius, hand, and five fingers" alongside "have bionic arm", and then act as if the arm was actually gone.

**Fix:** Before listing missing parts, a set of all body parts with an installed prosthetic or bionic is built. Each missing part is then checked against this set by walking up the body part hierarchy. If any ancestor has a prosthetic installed, the missing part is silently skipped.

Applied in:
- `ColonistPromptContextBuilder.cs` — individual colonist chat
- `PawnConversationPromptBuilder.cs` — pawn-to-pawn conversations (two locations: health conditions and mobility detection)

---

### Fix: Trait descriptions now included in prompts

Trait names alone (e.g. `Transhumanist`, `Psychopath`) are not enough for the AI to understand their meaning in the RimWorld context. This caused colonists to act contrary to their traits — a confirmed example being a Transhumanist colonist saying they preferred their flesh-and-blood limbs when bionics were mentioned.

**Fix:** Each trait now includes its in-game description alongside its name, trimmed to a reasonable length to keep token usage manageable.

Applied in:
- `ColonistPromptContextBuilder.cs` — individual colonist chat
- `PawnConversationPromptBuilder.cs` — pawn-to-pawn conversations
- `PawnMonologuePromptBuilder.cs` — colonist monologues

---

### Other changes
- `GeminiAPI.cs` — minor adjustments
- `GeminiSettings.cs` — minor adjustments
- `MyMod.cs` — minor adjustments